### PR TITLE
fix: fixed wasm resizing to be restricted by browser viewport

### DIFF
--- a/tetanes/src/nes/config.rs
+++ b/tetanes/src/nes/config.rs
@@ -339,10 +339,17 @@ impl Config {
     }
 
     #[must_use]
-    pub fn window_size(&self) -> egui::Vec2 {
-        let scale = self.renderer.scale;
+    pub fn window_size(&self, aspect_ratio: f32) -> egui::Vec2 {
+        self.window_size_for_scale(aspect_ratio, self.renderer.scale)
+    }
+
+    #[must_use]
+    pub fn window_size_for_scale(&self, aspect_ratio: f32, scale: f32) -> egui::Vec2 {
         let texture_size = self.texture_size();
-        egui::Vec2::new(scale * texture_size.x, scale * texture_size.y)
+        egui::Vec2::new(
+            (scale * aspect_ratio * texture_size.x).ceil(),
+            (scale * texture_size.y).ceil(),
+        )
     }
 
     #[must_use]

--- a/tetanes/src/nes/emulation.rs
+++ b/tetanes/src/nes/emulation.rs
@@ -567,7 +567,7 @@ impl State {
             ConfigEvent::ZapperConnected(connected) => {
                 self.control_deck.connect_zapper(*connected);
             }
-            ConfigEvent::HideOverscan(_) | ConfigEvent::InputBindings | ConfigEvent::Scale(_) => (),
+            ConfigEvent::HideOverscan(_) | ConfigEvent::InputBindings => (),
         }
     }
 

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -99,7 +99,6 @@ pub enum ConfigEvent {
     RewindInterval(u32),
     RunAhead(usize),
     SaveSlot(u8),
-    Scale(f32),
     Speed(f32),
     VideoFilter(VideoFilter),
     ZapperConnected(bool),
@@ -333,7 +332,9 @@ impl Running {
             Event::WindowEvent {
                 window_id, event, ..
             } => {
-                let res = self.renderer.on_window_event(window_id, &event);
+                let res = self
+                    .renderer
+                    .on_window_event(window_id, &event, &mut self.cfg);
                 if res.repaint {
                     self.repaint_times.insert(window_id, Instant::now());
                 }

--- a/tetanes/src/nes/renderer/gui.rs
+++ b/tetanes/src/nes/renderer/gui.rs
@@ -3,7 +3,7 @@ use crate::{
         action::{Action, Debug, DebugStep, Debugger, Feature, Setting, Ui as UiAction},
         config::Config,
         emulation::FrameStats,
-        event::{ConfigEvent, EmulationEvent, NesEvent, SendNesEvent, UiEvent},
+        event::{ConfigEvent, EmulationEvent, NesEvent, RendererEvent, SendNesEvent, UiEvent},
         input::{ActionBindings, Gamepads, Input},
         rom::{RomAsset, HOMEBREW_ROMS},
         version::Version,
@@ -1194,9 +1194,7 @@ impl Gui {
             if ui.add(button).clicked() {
                 let new_scale = cfg.increment_scale();
                 if scale != new_scale {
-                    self.resize_window = true;
-                    self.resize_texture = true;
-                    self.tx.nes_event(ConfigEvent::Scale(cfg.renderer.scale));
+                    self.tx.nes_event(RendererEvent::ScaleChanged);
                 }
             }
 
@@ -1205,9 +1203,7 @@ impl Gui {
             if ui.add(button).clicked() {
                 let new_scale = cfg.decrement_scale();
                 if scale != new_scale {
-                    self.resize_window = true;
-                    self.resize_texture = true;
-                    self.tx.nes_event(ConfigEvent::Scale(cfg.renderer.scale));
+                    self.tx.nes_event(RendererEvent::ScaleChanged);
                 }
             }
 
@@ -2575,9 +2571,7 @@ impl Gui {
             ui.radio_value(&mut cfg.renderer.scale, 5.0, "5x");
         });
         if scale != cfg.renderer.scale {
-            self.resize_window = true;
-            self.resize_texture = true;
-            self.tx.nes_event(ConfigEvent::Scale(cfg.renderer.scale));
+            self.tx.nes_event(RendererEvent::ScaleChanged);
         }
     }
 

--- a/tetanes/src/sys/platform/wasm.rs
+++ b/tetanes/src/sys/platform/wasm.rs
@@ -59,7 +59,7 @@ impl Initialize for Running {
         for input_id in [html_ids::ROM_INPUT, html_ids::REPLAY_INPUT] {
             let on_change = Closure::<dyn FnMut(_)>::new({
                 let tx = self.tx.clone();
-                move |evt: web_sys::MouseEvent| {
+                move |evt: web_sys::Event| {
                     match FileReader::new() {
                         Ok(reader) => {
                             let Some(file) = evt
@@ -73,7 +73,7 @@ impl Initialize for Running {
                             };
                             match reader.read_as_array_buffer(&file) {
                                 Ok(_) => {
-                                    let onload = Closure::<dyn FnMut()>::new({
+                                    let on_load = Closure::<dyn FnMut()>::new({
                                         let reader = reader.clone();
                                         let tx = tx.clone();
                                         move || match reader.result() {
@@ -97,8 +97,8 @@ impl Initialize for Running {
                                             Err(err) => on_error(&tx, err),
                                         }
                                     });
-                                    reader.set_onload(Some(onload.as_ref().unchecked_ref()));
-                                    onload.forget();
+                                    reader.set_onload(Some(on_load.as_ref().unchecked_ref()));
+                                    on_load.forget();
                                 }
                                 Err(err) => on_error(&tx, err),
                             }
@@ -110,7 +110,7 @@ impl Initialize for Running {
 
             let on_cancel = Closure::<dyn FnMut(_)>::new({
                 let tx = self.tx.clone();
-                move |_: web_sys::MouseEvent| tx.nes_event(UiEvent::FileDialogCancelled)
+                move |_: web_sys::Event| tx.nes_event(UiEvent::FileDialogCancelled)
             });
 
             let input = document

--- a/tetanes/src/sys/platform/wasm.rs
+++ b/tetanes/src/sys/platform/wasm.rs
@@ -170,14 +170,14 @@ mod html_ids {
     pub(super) const REPLAY_INPUT: &str = "load-replay";
 }
 
-fn get_canvas() -> Option<web_sys::HtmlCanvasElement> {
+pub fn get_canvas() -> Option<web_sys::HtmlCanvasElement> {
     window()
         .and_then(|win| win.document())
         .and_then(|doc| doc.get_element_by_id(html_ids::CANVAS))
         .and_then(|canvas| canvas.dyn_into::<HtmlCanvasElement>().ok())
 }
 
-fn focus_canvas() {
+pub fn focus_canvas() {
     if let Some(canvas) = get_canvas() {
         let _ = canvas.focus();
     }


### PR DESCRIPTION
Fixes an issue where increasing the window scale or changing the browser width with a scale that's too wide would result in the canvas width being constrained to the viewport, but not the height. The NES frame maintains it's aspect ratio, but there's no provided way to restrict the ratio of the window from winit

This fix restricts the height based on the regional aspect ratio of the loaded ROM and will resize the canvas when the browser size is changed emitting a warning any time the configured window scale can't fit inside the browser viewport.