### PR TITLE
feat: added config and save/sram state persistence to web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "web-sys",
  "web-time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { version = "0.1", default-features = false, features = [
 tracing-subscriber = "0.3"
 serde_json = "1.0"
 web-time = "0.2" # FIXME: winit is using an old version
+web-sys = "0.3"
 
 # Playable framerates in development
 [profile.dev]

--- a/tetanes-core/Cargo.toml
+++ b/tetanes-core/Cargo.toml
@@ -43,6 +43,7 @@ enum_dispatch = "0.3"
 flate2 = "1.0"
 rand = "0.8"
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
@@ -52,6 +53,7 @@ puffin = { workspace = true, optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 puffin = { workspace = true, features = ["web"], optional = true }
 web-time.workspace = true
+web-sys = { workspace = true, features = ["Storage", "Window"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/tetanes-core/src/fs.rs
+++ b/tetanes-core/src/fs.rs
@@ -116,6 +116,9 @@ where
     let mut writer = fs::writer_impl(path)?;
     write_header(&mut writer).map_err(Error::WriteHeaderFailed)?;
     encode(&mut writer, &data).map_err(Error::EncodingFailed)?;
+    writer
+        .flush()
+        .map_err(|err| Error::io(err, "failed to save data"))?;
     Ok(())
 }
 
@@ -123,6 +126,9 @@ pub fn save_raw(path: impl AsRef<Path>, value: &[u8]) -> Result<()> {
     let mut writer = fs::writer_impl(path)?;
     writer
         .write_all(value)
+        .map_err(|err| Error::io(err, "failed to save data"))?;
+    writer
+        .flush()
         .map_err(|err| Error::io(err, "failed to save data"))?;
     Ok(())
 }
@@ -158,6 +164,10 @@ pub fn load_raw(path: impl AsRef<Path>) -> Result<Vec<u8>> {
 
 pub fn clear_dir(path: impl AsRef<Path>) -> Result<()> {
     fs::clear_dir_impl(path)
+}
+
+pub fn exists(path: &Path) -> bool {
+    fs::exists_impl(path)
 }
 
 pub fn filename(path: &Path) -> &str {

--- a/tetanes-core/src/sys/fs/os.rs
+++ b/tetanes-core/src/sys/fs/os.rs
@@ -30,3 +30,8 @@ pub fn clear_dir_impl(path: impl AsRef<Path>) -> Result<()> {
     remove_dir_all(path)
         .map_err(|source| Error::io(source, format!("failed to remove directory {path:?}")))
 }
+
+pub fn exists_impl(path: impl AsRef<Path>) -> bool {
+    let path = path.as_ref();
+    path.exists()
+}

--- a/tetanes-core/src/sys/fs/wasm.rs
+++ b/tetanes-core/src/sys/fs/wasm.rs
@@ -2,21 +2,120 @@
 
 use crate::fs::{Error, Result};
 use std::{
-    io::{Empty, Read, Write},
-    path::Path,
+    io::{self, Read, Write},
+    mem,
+    path::{Path, PathBuf},
 };
+use web_sys::js_sys;
 
-pub fn writer_impl(_path: impl AsRef<Path>) -> Result<impl Write> {
-    // TODO: provide file download
-    Err::<Empty, _>(Error::custom("not implemented: wasm write"))
+#[derive(Debug)]
+#[must_use]
+pub struct StoreWriter {
+    path: PathBuf,
+    data: Vec<u8>,
 }
 
-pub fn reader_impl(_path: impl AsRef<Path>) -> Result<impl Read> {
-    // TODO: provide file upload?
-    Err::<Empty, _>(Error::custom("not implemented: wasm read"))
+pub struct StoreReader {
+    cursor: io::Cursor<Vec<u8>>,
 }
 
-pub fn clear_dir_impl(_path: impl AsRef<Path>) -> Result<()> {
-    // TODO: clear storage
-    Err::<(), _>(Error::custom("not implemented: wasm clear dir"))
+fn local_storage() -> Result<web_sys::Storage> {
+    let window = web_sys::window().ok_or_else(|| Error::custom("failed to get js window"))?;
+    window
+        .local_storage()
+        .map_err(|err| {
+            tracing::error!("failed to get local storage: {err:?}");
+            Error::custom(format!("failed to get storage"))
+        })?
+        .ok_or_else(|| Error::custom("no storage available"))
+}
+
+impl Write for StoreWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.data.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let local_storage = local_storage().map_err(io::Error::other)?;
+
+        let key = self.path.to_string_lossy();
+        let data = mem::take(&mut self.data);
+        let value = match serde_json::to_string(&data) {
+            Ok(value) => value,
+            Err(err) => {
+                self.data = data;
+                tracing::error!("failed to serialize data: {err:?}");
+                return Err(io::Error::other("failed to serialize data"));
+            }
+        };
+
+        if let Err(err) = local_storage.set_item(&key, &value) {
+            self.data = data;
+            tracing::error!("failed to store data in local storage: {err:?}");
+            return Err(io::Error::other("failed to write data"));
+        }
+
+        Ok(())
+    }
+}
+
+impl Read for StoreReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.cursor.read(buf)
+    }
+}
+
+pub fn writer_impl(path: impl AsRef<Path>) -> Result<impl Write> {
+    let path = path.as_ref();
+    Ok(StoreWriter {
+        path: path.to_path_buf(),
+        data: Vec::new(),
+    })
+}
+
+pub fn reader_impl(path: impl AsRef<Path>) -> Result<impl Read> {
+    let path = path.as_ref();
+    let local_storage = local_storage()?;
+
+    let key = path.to_string_lossy().into_owned();
+    let data = local_storage
+        .get_item(&key)
+        .map_err(|_| Error::custom("failed to find data for {key}"))?
+        .map(|value| {
+            serde_json::from_str(&value).map_err(|err| {
+                tracing::error!("failed to deserialize data: {err:?}");
+                Error::custom("failed to deserialize data")
+            })
+        })
+        .unwrap_or_else(|| Ok(Vec::new()))?;
+
+    Ok(StoreReader {
+        cursor: io::Cursor::new(data),
+    })
+}
+
+pub fn clear_dir_impl(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref().to_string_lossy();
+    let local_storage = local_storage()?;
+
+    for key in js_sys::Object::keys(&local_storage)
+        .iter()
+        .filter_map(|key| key.as_string())
+        .filter(|key| key.starts_with(&*path))
+    {
+        let _ = local_storage.remove_item(&key);
+    }
+
+    Ok(())
+}
+
+pub fn exists_impl(path: impl AsRef<Path>) -> bool {
+    let path = path.as_ref();
+    let Ok(local_storage) = local_storage() else {
+        return false;
+    };
+
+    let key = path.to_string_lossy();
+    matches!(local_storage.get_item(&key), Ok(Some(_)))
 }

--- a/tetanes/Cargo.toml
+++ b/tetanes/Cargo.toml
@@ -100,8 +100,7 @@ getrandom = { version = "0.2", features = ["js"] }
 puffin = { workspace = true, features = ["web"], optional = true }
 tracing-web = "0.1"
 wgpu = { version = "0.19", features = ["webgl"] }
-web-sys = { version = "0.3", features = [
-  "Blob",
+web-sys = { workspace = true, features = [
   "Document",
   "DomTokenList",
   "Element",

--- a/tetanes/src/nes/audio.rs
+++ b/tetanes/src/nes/audio.rs
@@ -499,34 +499,32 @@ impl Mixer {
 
     fn start_recording(&mut self) -> anyhow::Result<()> {
         let _ = self.stop_recording();
-        if let Some(dir) = Config::default_audio_dir() {
-            let path = dir
-                .join(
-                    chrono::Local::now()
-                        .format("recording_%Y-%m-%d_at_%H_%M_%S")
-                        .to_string(),
-                )
-                .with_extension("wav");
-            if let Some(parent) = path.parent() {
-                if !parent.exists() {
-                    std::fs::create_dir_all(parent).with_context(|| {
-                        format!(
-                            "failed to create audio recording directory: {}",
-                            parent.display()
-                        )
-                    })?;
-                }
+        let path = Config::default_audio_dir()
+            .join(
+                chrono::Local::now()
+                    .format("recording_%Y-%m-%d_at_%H_%M_%S")
+                    .to_string(),
+            )
+            .with_extension("wav");
+        if let Some(parent) = path.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "failed to create audio recording directory: {}",
+                        parent.display()
+                    )
+                })?;
             }
-            let spec = hound::WavSpec {
-                channels: self.channels,
-                sample_rate: self.sample_rate,
-                bits_per_sample: 32,
-                sample_format: hound::SampleFormat::Float,
-            };
-            let writer = hound::WavWriter::create(&path, spec)
-                .context("failed to create audio recording")?;
-            self.recording = Some((path, writer));
         }
+        let spec = hound::WavSpec {
+            channels: self.channels,
+            sample_rate: self.sample_rate,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let writer =
+            hound::WavWriter::create(&path, spec).context("failed to create audio recording")?;
+        self.recording = Some((path, writer));
         Ok(())
     }
 

--- a/tetanes/src/nes/emulation/replay.rs
+++ b/tetanes/src/nes/emulation/replay.rs
@@ -56,24 +56,24 @@ impl Record {
         let Some(start) = self.start.take() else {
             return Ok(None);
         };
+
         if self.events.is_empty() {
             tracing::debug!("not saving - no replay events");
             return Ok(None);
         }
-        if let Some(dir) = Config::default_data_dir() {
-            let path = dir
-                .join(
-                    Local::now()
-                        .format(&format!("tetanes_replay_{name}_%Y-%m-%d_%H.%M.%S"))
-                        .to_string(),
-                )
-                .with_extension("replay");
-            let events = std::mem::take(&mut self.events);
-            fs::save(&path, &State((start, events)))?;
-            Ok(Some(path))
-        } else {
-            Err(anyhow::anyhow!("failed to find document directory"))
-        }
+
+        let replay_path = Config::default_data_dir()
+            .join(
+                Local::now()
+                    .format(&format!("tetanes_replay_{name}_%Y-%m-%d_%H.%M.%S"))
+                    .to_string(),
+            )
+            .with_extension("replay");
+        let events = std::mem::take(&mut self.events);
+
+        fs::save(&replay_path, &State((start, events)))?;
+
+        Ok(Some(replay_path))
     }
 }
 

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -506,7 +506,7 @@ impl Running {
                         .renderer
                         .roms_path
                         .as_ref()
-                        .map(|p| p.to_path_buf()),
+                        .map_or_else(|| PathBuf::from("."), |p| p.to_path_buf()),
                 ) {
                     Ok(maybe_path) => {
                         if let Some(path) = maybe_path {
@@ -852,7 +852,7 @@ impl Running {
                     | DeckAction::ZapperAimOffscreen
                     | DeckAction::ZapperTrigger => (),
                     DeckAction::SetSaveSlot(slot) if released => {
-                        if platform::supports(platform::Feature::Filesystem) {
+                        if platform::supports(platform::Feature::Storage) {
                             if self.cfg.emulation.save_slot != slot {
                                 self.cfg.emulation.save_slot = slot;
                                 self.renderer.add_message(
@@ -868,7 +868,7 @@ impl Running {
                         }
                     }
                     DeckAction::SaveState if released && is_root_window => {
-                        if platform::supports(platform::Feature::Filesystem) {
+                        if platform::supports(platform::Feature::Storage) {
                             self.nes_event(EmulationEvent::SaveState(self.cfg.emulation.save_slot));
                         } else {
                             self.renderer.add_message(
@@ -878,7 +878,7 @@ impl Running {
                         }
                     }
                     DeckAction::LoadState if released && is_root_window => {
-                        if platform::supports(platform::Feature::Filesystem) {
+                        if platform::supports(platform::Feature::Storage) {
                             self.nes_event(EmulationEvent::LoadState(self.cfg.emulation.save_slot));
                         } else {
                             self.renderer.add_message(

--- a/tetanes/src/platform.rs
+++ b/tetanes/src/platform.rs
@@ -26,7 +26,7 @@ pub fn open_file_dialog(
     title: impl Into<String>,
     name: impl Into<String>,
     extensions: &[impl ToString],
-    dir: Option<PathBuf>,
+    dir: PathBuf,
 ) -> anyhow::Result<Option<PathBuf>> {
     platform::open_file_dialog_impl(title, name, extensions, dir)
 }
@@ -35,6 +35,7 @@ pub fn open_file_dialog(
 #[must_use]
 pub enum Feature {
     Filesystem,
+    Storage,
     Viewports,
     Suspend,
 }

--- a/tetanes/src/sys/platform/os.rs
+++ b/tetanes/src/sys/platform/os.rs
@@ -13,7 +13,7 @@ use winit::{
 pub const fn supports_impl(feature: Feature) -> bool {
     match feature {
         Feature::Suspend => cfg!(target_os = "android"),
-        Feature::Filesystem | Feature::Viewports => true,
+        Feature::Filesystem | Feature::Storage | Feature::Viewports => true,
     }
 }
 
@@ -21,14 +21,12 @@ pub fn open_file_dialog_impl(
     title: impl Into<String>,
     name: impl Into<String>,
     extensions: &[impl ToString],
-    dir: Option<PathBuf>,
+    dir: PathBuf,
 ) -> anyhow::Result<Option<PathBuf>> {
-    let mut dialog = rfd::FileDialog::new()
+    let dialog = rfd::FileDialog::new()
         .set_title(title)
+        .set_directory(dir)
         .add_filter(name, extensions);
-    if let Some(dir) = dir {
-        dialog = dialog.set_directory(dir);
-    }
     Ok(dialog.pick_file())
 }
 


### PR DESCRIPTION
Adds basic configuration persistence across sessions and allows for saving/loading of save states/battery backed ram.

Exporting of save/load/sram states is left for #275 

Implementation is built on localStorage which works, but is crude and generally not intended for binary data. Performance has generally not been too noticeable, given the small binary sizes, but may be a consideration for future enhancement.

IndexedDB or Origin Private File System may be more appropriate storage mechanisms for web, but both are currently asynchronous while the desktop storage implementation is not, requiring either diverging APIs across platforms, or a complete switch to async I/O across the board.

Closes #270 and #271 