### PR TITLE
Clipboard web

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["-Z", "threads=8"]
+
+[target.'cfg(target_arch = "wasm32")']
+rustflags = ["-Z", "threads=8", "--cfg=web_sys_unstable_apis"]

--- a/tetanes/Cargo.toml
+++ b/tetanes/Cargo.toml
@@ -99,6 +99,9 @@ puffin = { workspace = true, features = ["web"], optional = true }
 tracing-web = "0.1"
 wgpu = { version = "0.19", features = ["webgl"] }
 web-sys = { workspace = true, features = [
+  "Clipboard",
+  "ClipboardEvent",
+  "DataTransfer",
   "Document",
   "DomTokenList",
   "Element",

--- a/tetanes/src/nes.rs
+++ b/tetanes/src/nes.rs
@@ -182,13 +182,14 @@ impl Nes {
                     .init_state
                     .take()
                     .context("config unexpectedly already taken")?;
-                let emulation = Emulation::new(tx.clone(), frame_tx.clone(), cfg.clone())?;
-                let renderer =
-                    Renderer::new(tx.clone(), event_loop, resources, frame_rx, cfg.clone())?;
 
                 let input_bindings = InputBindings::from_input_config(&cfg.input);
                 let gamepads = Gamepads::new();
                 cfg.input.update_gamepad_assignments(&gamepads);
+
+                let emulation = Emulation::new(tx.clone(), frame_tx.clone(), &cfg)?;
+                let renderer = Renderer::new(tx.clone(), event_loop, resources, frame_rx, &cfg)?;
+
                 let mut running = Running {
                     cfg,
                     tx,

--- a/tetanes/src/nes/audio.rs
+++ b/tetanes/src/nes/audio.rs
@@ -347,14 +347,11 @@ impl Output {
                 };
                 let supported =
                     supports_sample_rate && supports_sample_format && supports_buffer_size;
-                debug!(
-                    "{} config: {config:?}",
-                    if supported {
-                        "supported"
-                    } else {
-                        "unsupported"
-                    }
-                );
+                if supported {
+                    debug!("supported config: {config:?}",);
+                } else {
+                    trace!("unsupported config: {config:?}",);
+                }
                 supported
             })
             .or_else(|| {

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -13,7 +13,7 @@ use crate::{
 use anyhow::anyhow;
 use egui::ViewportId;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tetanes_core::{
     action::Action as DeckAction,
     apu::Channel,
@@ -482,16 +482,13 @@ impl Running {
             UiEvent::Message((ty, msg)) => self.renderer.add_message(ty, msg),
             UiEvent::Error(err) => self.renderer.on_error(anyhow!(err)),
             UiEvent::LoadRomDialog => {
-                match open_file_dialog(
-                    "Load ROM",
-                    "NES ROMs",
-                    &["nes"],
-                    self.cfg
-                        .renderer
-                        .roms_path
-                        .as_ref()
-                        .map_or_else(|| PathBuf::from("."), |p| p.to_path_buf()),
-                ) {
+                let dir = self
+                    .cfg
+                    .renderer
+                    .roms_path
+                    .as_deref()
+                    .unwrap_or_else(|| Path::new("."));
+                match open_file_dialog("Load ROM", "NES ROMs", &["nes"], dir) {
                     Ok(maybe_path) => {
                         if let Some(path) = maybe_path {
                             self.nes_event(EmulationEvent::LoadRomPath(path));

--- a/tetanes/src/nes/input.rs
+++ b/tetanes/src/nes/input.rs
@@ -212,27 +212,6 @@ impl ActionBindings {
                 { (Player::One, JoypadBtn::Select) => KeyW },
                 { (Player::One, JoypadBtn::Start) => KeyQ },
             ),
-            Player::Two => shortcut_map!(
-                { (Player::Two, JoypadBtn::A) => KeyN },
-                { (Player::Two, JoypadBtn::B) => KeyM },
-                { (Player::Two, JoypadBtn::Up) => KeyI },
-                { (Player::Two, JoypadBtn::Down) => KeyK },
-                { (Player::Two, JoypadBtn::Left) => KeyJ },
-                { (Player::Two, JoypadBtn::Right) => KeyL },
-                { (Player::Two, JoypadBtn::Select) => Digit9 },
-                { (Player::Two, JoypadBtn::Start) => Digit8 },
-            ),
-            #[cfg(debug_assertions)]
-            Player::Three => shortcut_map!(
-                { (Player::Three, JoypadBtn::A) => KeyV },
-                { (Player::Three, JoypadBtn::B) => KeyB },
-                { (Player::Three, JoypadBtn::Up) => KeyT },
-                { (Player::Three, JoypadBtn::Down) => KeyG },
-                { (Player::Three, JoypadBtn::Left) => KeyF },
-                { (Player::Three, JoypadBtn::Right) => KeyH },
-                { (Player::Three, JoypadBtn::Select) => Digit6 },
-                { (Player::Three, JoypadBtn::Start) => Digit5 },
-            ),
             _ => Vec::new(),
         };
 

--- a/tetanes/src/nes/input.rs
+++ b/tetanes/src/nes/input.rs
@@ -254,12 +254,12 @@ impl ActionBindings {
 pub struct InputBindings(HashMap<Input, Action>);
 
 impl InputBindings {
-    pub fn from_input_config(config: &InputConfig) -> Self {
+    pub fn from_input_config(cfg: &InputConfig) -> Self {
         let mut map = HashMap::with_capacity(256);
-        for bind in config
+        for bind in cfg
             .shortcuts
             .iter()
-            .chain(config.joypad_bindings.iter().flatten())
+            .chain(cfg.joypad_bindings.iter().flatten())
         {
             for input in bind.bindings.into_iter().flatten() {
                 map.insert(input, bind.action);

--- a/tetanes/src/nes/renderer.rs
+++ b/tetanes/src/nes/renderer.rs
@@ -1240,7 +1240,9 @@ impl Renderer {
             // Update viewports
             for (viewport_id, viewport) in viewports {
                 if self.gui.borrow().viewport_info_open {
-                    egui::Window::new("Viewport Info").show(&self.ctx, |ui| viewport.info.ui(ui));
+                    egui::Window::new(format!("Viewport Info ({viewport_id:?})"))
+                        .open(&mut self.gui.borrow_mut().viewport_info_open)
+                        .show(&self.ctx, |ui| viewport.info.ui(ui));
                 }
                 if always_on_top != cfg.renderer.always_on_top {
                     self.ctx.send_viewport_cmd_to(

--- a/tetanes/src/sys/platform/os.rs
+++ b/tetanes/src/sys/platform/os.rs
@@ -1,5 +1,5 @@
 use crate::{
-    nes::{event::EmulationEvent, Running},
+    nes::{event::EmulationEvent, renderer::Renderer, Running},
     platform::{BuilderExt, EventLoopExt, Feature, Initialize},
 };
 use std::path::{Path, PathBuf};
@@ -46,6 +46,12 @@ impl Initialize for Running {
             }
         }
 
+        Ok(())
+    }
+}
+
+impl Initialize for Renderer {
+    fn initialize(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
Adds support for clipboard in tetanes-web which required a bit of an overhaul to manage the event handler callback correctly for transient activation. Required adding back unstable apis flag. See: https://docs.rs/web-sys/latest/web_sys/struct.Clipboard.html

Fixed cleaned up some unrelated things 