### PR TITLE
feat: enable webgpu for browsers that support it. closes #297

### DIFF
--- a/tetanes/Cargo.toml
+++ b/tetanes/Cargo.toml
@@ -95,7 +95,7 @@ egui-winit = { version = "0.27", default-features = false, features = [
 getrandom = { version = "0.2", features = ["js"] }
 puffin = { workspace = true, features = ["web"], optional = true }
 tracing-web = "0.1"
-wgpu = { version = "0.19", features = ["webgl"] }
+wgpu = { version = "0.19", features = ["webgl", "webgpu"] }
 web-sys = { workspace = true, features = [
   "Clipboard",
   "ClipboardEvent",


### PR DESCRIPTION
Enabled webgpu. Tested on Ubuntu Chrome and Firefox nightly and seems to work well. Will test on other platforms to be sure, but I suspect the fix in #251 waiting for the window (e.g. canvas) to be initialized with a non-zero size was the cause for failure previously when attempting to enable webgpu, as creating the window seems to take a non-trivial amount of time more than webgl.