### PR TITLE
Deferred viewports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           # TODO: pin nightly temporarily to fix coreaudio-sys issue with 2024-06-23
           # See: https://github.com/RustAudio/coreaudio-sys/issues/104
-          toolchain: nightly-2024-06-12
+          toolchain: nightly-2024-06-22
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           # TODO: pin nightly temporarily to fix coreaudio-sys issue with 2024-06-23
           # See: https://github.com/RustAudio/coreaudio-sys/issues/104
-          toolchain: nightly-2024-06-22
+          toolchain: nightly-2024-06-16
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     name: Lint TetaNES (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
@@ -60,7 +61,9 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          # TODO: pin nightly temporarily to fix coreaudio-sys issue with 2024-06-23
+          # See: https://github.com/RustAudio/coreaudio-sys/issues/104
+          toolchain: nightly-2024-06-12
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - if: startsWith(matrix.os, 'ubuntu')
@@ -74,6 +77,7 @@ jobs:
     name: Lint TetaNES Core (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         toolchain: [nightly, stable, 1.78]

--- a/tetanes/src/bin/build_artifacts.rs
+++ b/tetanes/src/bin/build_artifacts.rs
@@ -294,7 +294,7 @@ impl Build {
         let volume = PathBuf::from("/Volumes").join(&artifact_name);
         let app_name = format!("{}.app", self.app_name);
         let dmg_name = format!("{artifact_name}-uncompressed.dmg");
-        let dmg_path = build_dir.join(&dmg_name);
+        let dmg_path = build_dir.join(dmg_name);
         let dmg_name_compressed = format!("{artifact_name}.dmg");
         let dmg_path_compressed = build_dir.join(&dmg_name_compressed);
         let dmg_path_dist = self.dist_dir.join(&dmg_name_compressed);

--- a/tetanes/src/nes.rs
+++ b/tetanes/src/nes.rs
@@ -166,7 +166,10 @@ impl Nes {
     ///
     /// If GPU resources failed to be requested, the emulation or renderer fails to build, then an
     /// error is returned.
-    pub(crate) fn init_running(&mut self) -> anyhow::Result<()> {
+    pub(crate) fn init_running(
+        &mut self,
+        event_loop: &EventLoopWindowTarget<NesEvent>,
+    ) -> anyhow::Result<()> {
         match std::mem::take(&mut self.state) {
             State::Pending {
                 ctx,
@@ -191,7 +194,7 @@ impl Nes {
                 cfg.input.update_gamepad_assignments(&gamepads);
 
                 let emulation = Emulation::new(tx.clone(), frame_tx.clone(), &cfg)?;
-                let renderer = Renderer::new(tx.clone(), resources, frame_rx, &cfg)?;
+                let renderer = Renderer::new(tx.clone(), event_loop, resources, frame_rx, &cfg)?;
 
                 let mut running = Running {
                     cfg,

--- a/tetanes/src/nes.rs
+++ b/tetanes/src/nes.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     nes::{
-        event::{RendererEvent, RunState, SendNesEvent, UiEvent},
+        event::{NesEventProxy, RendererEvent, RunState, UiEvent},
         input::{Gamepads, InputBindings},
         renderer::{FrameRecycle, Resources},
     },
@@ -23,7 +23,7 @@ use thingbuf::mpsc::blocking;
 use tracing::{debug, error};
 use winit::{
     event::Modifiers,
-    event_loop::{EventLoop, EventLoopBuilder, EventLoopProxy, EventLoopWindowTarget},
+    event_loop::{EventLoop, EventLoopBuilder, EventLoopWindowTarget},
     window::{Window, WindowId},
 };
 
@@ -44,7 +44,7 @@ pub struct Nes {
     /// Set during initialization, then taken and set to `None` when running because
     /// `EventLoopProxy` can only be created on the initial `EventLoop` and not on
     /// `&EventLoopWindowTarget`.
-    pub(crate) init_state: Option<(Config, EventLoopProxy<NesEvent>)>,
+    pub(crate) init_state: Option<(Config, NesEventProxy)>,
     /// Initially `Suspended`. `Pending` after `Resume` event received and spanwed. `Running` after
     /// resources future completes.
     pub(crate) state: State,
@@ -76,7 +76,7 @@ pub(crate) struct Running {
     pub(crate) cfg: Config,
     // Only used by wasm currently
     #[allow(unused)]
-    pub(crate) tx: EventLoopProxy<NesEvent>,
+    pub(crate) tx: NesEventProxy,
     pub(crate) emulation: Emulation,
     pub(crate) renderer: Renderer,
     pub(crate) input_bindings: InputBindings,
@@ -106,9 +106,8 @@ impl Nes {
 
     /// Create the NES instance.
     pub fn new(cfg: Config, event_loop: &EventLoop<NesEvent>) -> Self {
-        let tx = event_loop.create_proxy();
         Self {
-            init_state: Some((cfg, tx)),
+            init_state: Some((cfg, NesEventProxy::new(event_loop))),
             state: State::Suspended,
         }
     }
@@ -140,11 +139,11 @@ impl Nes {
                 match Renderer::create_painter(window).await {
                     Ok(painter) => {
                         painter_tx.send(painter).expect("failed to send painter");
-                        event_tx.nes_event(RendererEvent::ResourcesReady);
+                        event_tx.event(RendererEvent::ResourcesReady);
                     }
                     Err(err) => {
                         error!("failed to create painter: {err:?}");
-                        event_tx.nes_event(UiEvent::Terminate);
+                        event_tx.event(UiEvent::Terminate);
                     }
                 }
             }
@@ -167,10 +166,7 @@ impl Nes {
     ///
     /// If GPU resources failed to be requested, the emulation or renderer fails to build, then an
     /// error is returned.
-    pub(crate) fn init_running(
-        &mut self,
-        event_loop: &EventLoopWindowTarget<NesEvent>,
-    ) -> anyhow::Result<()> {
+    pub(crate) fn init_running(&mut self) -> anyhow::Result<()> {
         match std::mem::take(&mut self.state) {
             State::Pending {
                 ctx,
@@ -195,7 +191,7 @@ impl Nes {
                 cfg.input.update_gamepad_assignments(&gamepads);
 
                 let emulation = Emulation::new(tx.clone(), frame_tx.clone(), &cfg)?;
-                let renderer = Renderer::new(tx.clone(), event_loop, resources, frame_rx, &cfg)?;
+                let renderer = Renderer::new(tx.clone(), resources, frame_rx, &cfg)?;
 
                 let mut running = Running {
                     cfg,

--- a/tetanes/src/nes/action.rs
+++ b/tetanes/src/nes/action.rs
@@ -23,6 +23,18 @@ pub enum Action {
     Debug(Debug),
 }
 
+impl PartialOrd for Action {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Action {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
 impl Action {
     pub const BINDABLE: [Self; 111] = [
         Self::Ui(Ui::Quit),
@@ -173,9 +185,10 @@ impl AsRef<str> for Action {
             },
             Action::Menu(menu) => match menu {
                 Menu::About => "Toggle About Window",
-                Menu::Keybinds => "Toggle Keybinds Window",
+                Menu::Keybinds => "Toggle Keybinds Menu",
                 Menu::PerfStats => "Toggle Performance Stats Window",
-                Menu::Preferences => "Toggle Preferences Window",
+                Menu::PpuViewer => "Toggle PPU Viewer",
+                Menu::Preferences => "Toggle Preferences Menu",
             },
             Action::Feature(feature) => match feature {
                 Feature::ToggleReplayRecording => "Toggle Replay Recording",
@@ -281,6 +294,124 @@ impl AsRef<str> for Action {
                 },
             },
         }
+    }
+}
+
+impl TryFrom<&str> for Action {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Ok(match s {
+            "Quit" => Self::Ui(Ui::Quit),
+            "Toggle Pause" => Self::Ui(Ui::TogglePause),
+            "Load ROM" => Self::Ui(Ui::LoadRom),
+            "Unload ROM" => Self::Ui(Ui::UnloadRom),
+            "Load Replay" => Self::Ui(Ui::LoadReplay),
+            "Toggle About Window" => Self::Menu(Menu::About),
+            "Toggle Keybinds Menu" => Self::Menu(Menu::Keybinds),
+            "Toggle Performance Stats Window" => Self::Menu(Menu::PerfStats),
+            "Toggle PPU Viewer" => Self::Menu(Menu::PpuViewer),
+            "Toggle Preferences Menu" => Self::Menu(Menu::Preferences),
+            "Toggle Replay Recording" => Self::Feature(Feature::ToggleReplayRecording),
+            "Toggle Audio Recording" => Self::Feature(Feature::ToggleAudioRecording),
+            "Visual Rewind" => Self::Feature(Feature::VisualRewind),
+            "Instant Rewind" => Self::Feature(Feature::InstantRewind),
+            "Take Screenshot" => Self::Feature(Feature::TakeScreenshot),
+            "Toggle Fullscreen" => Self::Setting(Setting::ToggleFullscreen),
+            "Toggle Embed Viewports" => Self::Setting(Setting::ToggleEmbedViewports),
+            "Toggle Always On Top" => Self::Setting(Setting::ToggleAlwaysOnTop),
+            "Toggle Audio" => Self::Setting(Setting::ToggleAudio),
+            "Toggle Cycle Accurate" => Self::Setting(Setting::ToggleCycleAccurate),
+            "Toggle Rewinding" => Self::Setting(Setting::ToggleRewinding),
+            "Toggle Overscan" => Self::Setting(Setting::ToggleOverscan),
+            "Toggle Menubar" => Self::Setting(Setting::ToggleMenubar),
+            "Toggle Messages" => Self::Setting(Setting::ToggleMessages),
+            "Toggle FPS" => Self::Setting(Setting::ToggleFps),
+            "Fast Forward" => Self::Setting(Setting::FastForward),
+            "Increment Scale" => Self::Setting(Setting::IncrementScale),
+            "Decrement Scale" => Self::Setting(Setting::DecrementScale),
+            "Increment Speed" => Self::Setting(Setting::IncrementSpeed),
+            "Decrement Speed" => Self::Setting(Setting::DecrementSpeed),
+            "Reset" => Self::Deck(DeckAction::Reset(ResetKind::Soft)),
+            "Power Cycle" => Self::Deck(DeckAction::Reset(ResetKind::Hard)),
+            "Joypad Left (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::Left))),
+            "Joypad Right (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::Right))),
+            "Joypad Up (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::Up))),
+            "Joypad Down (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::Down))),
+            "Joypad A (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::A))),
+            "Joypad B (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::B))),
+            "Joypad Turbo A (P1)" => {
+                Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::TurboA)))
+            }
+            "Joypad Turbo B (P1)" => {
+                Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::TurboB)))
+            }
+            "Joypad Select (P1)" => {
+                Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::Select)))
+            }
+            "Joypad Start (P1)" => Self::Deck(DeckAction::Joypad((Player::One, JoypadBtn::Start))),
+            "Toggle Zapper Connected" => Self::Deck(DeckAction::ToggleZapperConnected),
+            "Zapper Aim" => Self::Deck(DeckAction::ZapperAim((0, 0))),
+            "Zapper Aim Offscreen (Hold)" => Self::Deck(DeckAction::ZapperAimOffscreen),
+            "Zapper Trigger" => Self::Deck(DeckAction::ZapperTrigger),
+            "Disable Four Player Mode" => Self::Deck(DeckAction::FourPlayer(FourPlayer::Disabled)),
+            "Enable Four Player (FourScore)" => {
+                Self::Deck(DeckAction::FourPlayer(FourPlayer::FourScore))
+            }
+            "Enable Four Player (Satellite)" => {
+                Self::Deck(DeckAction::FourPlayer(FourPlayer::Satellite))
+            }
+            "Set Save Slot 1" => Self::Deck(DeckAction::SetSaveSlot(1)),
+            "Set Save Slot 2" => Self::Deck(DeckAction::SetSaveSlot(2)),
+            "Set Save Slot 3" => Self::Deck(DeckAction::SetSaveSlot(3)),
+            "Set Save Slot 4" => Self::Deck(DeckAction::SetSaveSlot(4)),
+            "Set Save Slot 5" => Self::Deck(DeckAction::SetSaveSlot(5)),
+            "Set Save Slot 6" => Self::Deck(DeckAction::SetSaveSlot(6)),
+            "Set Save Slot 7" => Self::Deck(DeckAction::SetSaveSlot(7)),
+            "Set Save Slot 8" => Self::Deck(DeckAction::SetSaveSlot(8)),
+            "Save State" => Self::Deck(DeckAction::SaveState),
+            "Load State" => Self::Deck(DeckAction::LoadState),
+            "Toggle Pulse1 Channel" => Self::Deck(DeckAction::ToggleApuChannel(Channel::Pulse1)),
+            "Toggle Pulse2 Channel" => Self::Deck(DeckAction::ToggleApuChannel(Channel::Pulse2)),
+            "Toggle Triangle Channel" => {
+                Self::Deck(DeckAction::ToggleApuChannel(Channel::Triangle))
+            }
+            "Toggle Noise Channel" => Self::Deck(DeckAction::ToggleApuChannel(Channel::Noise)),
+            "Toggle DMC Channel" => Self::Deck(DeckAction::ToggleApuChannel(Channel::Dmc)),
+            "Toggle Mapper Channel" => Self::Deck(DeckAction::ToggleApuChannel(Channel::Mapper)),
+            "Set Mapper Rev. to MMC3A" => Self::Deck(DeckAction::MapperRevision(
+                MapperRevision::Mmc3(Mmc3Revision::A),
+            )),
+            "Set Mapper Rev. to MMC3B/C" => Self::Deck(DeckAction::MapperRevision(
+                MapperRevision::Mmc3(Mmc3Revision::BC),
+            )),
+            "Set Mapper Rev. to MC-ACC" => Self::Deck(DeckAction::MapperRevision(
+                MapperRevision::Mmc3(Mmc3Revision::Acc),
+            )),
+            "Set Mapper Rev. to BF909x" => Self::Deck(DeckAction::MapperRevision(
+                MapperRevision::Bf909(Bf909Revision::Bf909x),
+            )),
+            "Set Mapper Rev. to BF9097" => Self::Deck(DeckAction::MapperRevision(
+                MapperRevision::Bf909(Bf909Revision::Bf9097),
+            )),
+            "Set Region to Auto-Detect" => Self::Deck(DeckAction::SetNesRegion(NesRegion::Auto)),
+            "Set Region to NTSC" => Self::Deck(DeckAction::SetNesRegion(NesRegion::Ntsc)),
+            "Set Region to PAL" => Self::Deck(DeckAction::SetNesRegion(NesRegion::Pal)),
+            "Set Region to Dendy" => Self::Deck(DeckAction::SetNesRegion(NesRegion::Dendy)),
+            "Set Filter to Pixellate" => {
+                Self::Deck(DeckAction::SetVideoFilter(VideoFilter::Pixellate))
+            }
+            "Set Filter to NTSC" => Self::Deck(DeckAction::SetVideoFilter(VideoFilter::Ntsc)),
+            "Toggle CPU Debugger" => Self::Debug(Debug::Toggle(Debugger::Cpu)),
+            "Toggle PPU Debugger" => Self::Debug(Debug::Toggle(Debugger::Ppu)),
+            "Toggle APU Debugger" => Self::Debug(Debug::Toggle(Debugger::Apu)),
+            "Step Into (CPU Debugger)" => Self::Debug(Debug::Step(DebugStep::Into)),
+            "Step Out (CPU Debugger)" => Self::Debug(Debug::Step(DebugStep::Out)),
+            "Step Over (CPU Debugger)" => Self::Debug(Debug::Step(DebugStep::Over)),
+            "Step Scanline (CPU Debugger)" => Self::Debug(Debug::Step(DebugStep::Scanline)),
+            "Step Frame (CPU Debugger)" => Self::Debug(Debug::Step(DebugStep::Frame)),
+            _ => return Err(anyhow::anyhow!("Invalid action string")),
+        })
     }
 }
 

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -506,6 +506,8 @@ impl Running {
                             }
                             ConfigEvent::AlwaysOnTop(always_on_top) => {
                                 renderer.always_on_top = *always_on_top;
+                                self.renderer
+                                    .set_always_on_top(self.cfg.renderer.always_on_top);
                             }
                             ConfigEvent::ApuChannelEnabled((channel, enabled)) => {
                                 deck.channels_enabled[*channel as usize] = *enabled;
@@ -582,6 +584,8 @@ impl Running {
                             ConfigEvent::VideoFilter(filter) => deck.filter = *filter,
                             ConfigEvent::ZapperConnected(connected) => deck.zapper = *connected,
                         }
+
+                        self.renderer.update(&self.gamepads, &self.cfg);
                     }
                     NesEvent::Renderer(RendererEvent::RequestRedraw { viewport_id, when }) => {
                         if let Some(window_id) = self.renderer.window_id_for_viewport(*viewport_id)
@@ -785,6 +789,8 @@ impl Running {
                 _ => (),
             }
         }
+
+        self.renderer.update(&self.gamepads, &self.cfg);
     }
 
     /// Handle user input mapped to key bindings.

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -265,7 +265,7 @@ impl Nes {
             }
             Event::UserEvent(event) => match event {
                 NesEvent::Renderer(RendererEvent::ResourcesReady) => {
-                    if let Err(err) = self.init_running() {
+                    if let Err(err) = self.init_running(event_loop) {
                         error!("failed to create window: {err:?}");
                         event_loop.exit();
                         return;
@@ -585,7 +585,7 @@ impl Running {
                             ConfigEvent::ZapperConnected(connected) => deck.zapper = *connected,
                         }
 
-                        self.renderer.update(&self.gamepads, &self.cfg);
+                        self.renderer.prepare(&self.gamepads, &self.cfg);
                     }
                     NesEvent::Renderer(RendererEvent::RequestRedraw { viewport_id, when }) => {
                         if let Some(window_id) = self.renderer.window_id_for_viewport(*viewport_id)
@@ -790,7 +790,7 @@ impl Running {
             }
         }
 
-        self.renderer.update(&self.gamepads, &self.cfg);
+        self.renderer.prepare(&self.gamepads, &self.cfg);
     }
 
     /// Handle user input mapped to key bindings.

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -1,9 +1,9 @@
 use crate::{
     nes::{
-        action::{Action, Debug, DebugStep, Feature, Setting, Ui},
+        action::{Action, Debug, DebugStep, Debugger, Feature, Setting, Ui},
         config::Config,
         emulation::FrameStats,
-        input::{AxisDirection, Gamepads, Input, InputBindings},
+        input::{ActionBindings, AxisDirection, Gamepads, Input, InputBindings},
         renderer::{
             gui::{Menu, MessageType},
             shader::Shader,
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tetanes_core::{
     action::Action as DeckAction,
-    apu::Channel,
+    apu::{Apu, Channel},
     common::{NesRegion, ResetKind},
     control_deck::{LoadedRom, MapperRevisionsConfig},
     genie::GenieCode,
@@ -29,22 +29,26 @@ use tetanes_core::{
     video::VideoFilter,
 };
 use tracing::{error, trace};
+use uuid::Uuid;
 use winit::{
     event::{ElementState, Event, WindowEvent},
-    event_loop::{ControlFlow, DeviceEvents, EventLoopProxy, EventLoopWindowTarget},
+    event_loop::{ControlFlow, DeviceEvents, EventLoop, EventLoopProxy, EventLoopWindowTarget},
     keyboard::PhysicalKey,
     window::WindowId,
 };
 
-pub trait SendNesEvent {
-    fn nes_event(&self, event: impl Into<NesEvent>);
-}
+#[derive(Debug, Clone)]
+pub struct NesEventProxy(EventLoopProxy<NesEvent>);
 
-impl SendNesEvent for EventLoopProxy<NesEvent> {
-    fn nes_event(&self, event: impl Into<NesEvent>) {
+impl NesEventProxy {
+    pub fn new(event_loop: &EventLoop<NesEvent>) -> Self {
+        Self(event_loop.create_proxy())
+    }
+
+    pub fn event(&self, event: impl Into<NesEvent>) {
         let event = event.into();
         trace!("sending event: {event:?}");
-        if let Err(err) = self.send_event(event) {
+        if let Err(err) = self.0.send_event(event) {
             error!("failed to send event: {err:?}");
             std::process::exit(1);
         }
@@ -81,7 +85,12 @@ impl AsRef<[u8]> for ReplayData {
 #[derive(Debug, Clone, PartialEq)]
 #[must_use]
 pub enum ConfigEvent {
+    ActionBindings(Vec<ActionBindings>),
+    ActionBindingSet((Action, Input, usize)),
+    ActionBindingClear(Input),
+    AlwaysOnTop(bool),
     ApuChannelEnabled((Channel, bool)),
+    ApuChannelsEnabled([bool; Apu::MAX_CHANNEL_COUNT]),
     AudioBuffer(usize),
     AudioEnabled(bool),
     AudioLatency(Duration),
@@ -90,20 +99,30 @@ pub enum ConfigEvent {
     AutoSaveInterval(Duration),
     ConcurrentDpad(bool),
     CycleAccurate(bool),
+    DarkTheme(bool),
+    EmbedViewports(bool),
     FourPlayer(FourPlayer),
+    Fullscreen(bool),
+    GamepadAssign((Player, Uuid)),
+    GamepadAssignments([(Player, Option<Uuid>); 4]),
+    GamepadUnassign(Player),
     GenieCodeAdded(GenieCode),
+    GenieCodeClear,
     GenieCodeRemoved(String),
     HideOverscan(bool),
-    InputBindings,
     MapperRevisions(MapperRevisionsConfig),
     RamState(RamState),
+    RecentRomsClear,
     Region(NesRegion),
     RewindEnabled(bool),
-    RewindSeconds(u32),
     RewindInterval(u32),
+    RewindSeconds(u32),
     RunAhead(usize),
     SaveSlot(u8),
+    Scale(f32),
     Shader(Shader),
+    ShowMenubar(bool),
+    ShowMessages(bool),
     Speed(f32),
     VideoFilter(VideoFilter),
     ZapperConnected(bool),
@@ -164,9 +183,10 @@ pub enum RendererEvent {
     ViewportResized((f32, f32)),
     FrameStats(FrameStats),
     ShowMenubar(bool),
-    ScaleChanged,
     ToggleFullscreen,
     ReplayLoaded,
+    ResizeTexture,
+    ResizeWindow,
     ResourcesReady,
     RequestRedraw {
         viewport_id: ViewportId,
@@ -245,7 +265,7 @@ impl Nes {
             }
             Event::UserEvent(event) => match event {
                 NesEvent::Renderer(RendererEvent::ResourcesReady) => {
-                    if let Err(err) = self.init_running(event_loop) {
+                    if let Err(err) = self.init_running() {
                         error!("failed to create window: {err:?}");
                         event_loop.exit();
                         return;
@@ -341,7 +361,8 @@ impl Running {
                 self.renderer
                     .add_message(MessageType::Warn, "Your system memory is running low...");
                 if self.cfg.emulation.rewind {
-                    self.nes_event(ConfigEvent::RewindEnabled(false));
+                    self.cfg.emulation.rewind = false;
+                    self.event(ConfigEvent::RewindEnabled(false));
                 }
             }
             Event::AboutToWait => {
@@ -352,7 +373,9 @@ impl Running {
                         self.repaint_times.insert(window_id, Instant::now());
                     }
 
-                    if !res.consumed {
+                    if res.consumed {
+                        self.gamepads.clear_events();
+                    } else {
                         while let Some(event) = self.gamepads.next_event() {
                             self.on_gamepad_event(window_id, event);
                             self.repaint_times.insert(window_id, Instant::now());
@@ -393,7 +416,7 @@ impl Running {
                                 self.repaint_times.insert(window_id, Instant::now());
                                 if self.renderer.rom_loaded() && self.run_state.auto_paused() {
                                     self.run_state = RunState::Running;
-                                    self.nes_event(EmulationEvent::RunState(self.run_state));
+                                    self.event(EmulationEvent::RunState(self.run_state));
                                 }
                             } else {
                                 let time_since_last_save =
@@ -412,7 +435,7 @@ impl Running {
                                     self.repaint_times.remove(&window_id);
                                     if self.renderer.rom_loaded() {
                                         self.run_state = RunState::Paused;
-                                        self.nes_event(EmulationEvent::RunState(self.run_state));
+                                        self.event(EmulationEvent::RunState(self.run_state));
                                     }
                                 }
                             }
@@ -423,13 +446,13 @@ impl Running {
                                 self.repaint_times.remove(&window_id);
                                 if self.renderer.rom_loaded() {
                                     self.run_state = RunState::Paused;
-                                    self.nes_event(EmulationEvent::RunState(self.run_state));
+                                    self.event(EmulationEvent::RunState(self.run_state));
                                 }
                             } else {
                                 self.repaint_times.insert(window_id, Instant::now());
                                 if self.renderer.rom_loaded() && self.run_state.auto_paused() {
                                     self.run_state = RunState::Running;
-                                    self.nes_event(EmulationEvent::RunState(self.run_state));
+                                    self.event(EmulationEvent::RunState(self.run_state));
                                 }
                             }
                         }
@@ -451,7 +474,7 @@ impl Running {
                         }
                         WindowEvent::DroppedFile(path) => {
                             if Some(window_id) == self.renderer.root_window_id() {
-                                self.nes_event(EmulationEvent::LoadRomPath(path));
+                                self.event(EmulationEvent::LoadRomPath(path));
                             }
                         }
                         _ => (),
@@ -459,29 +482,127 @@ impl Running {
                 }
             }
             Event::UserEvent(event) => {
-                // Only wake emulation of relevant events
-                if matches!(event, NesEvent::Emulation(_) | NesEvent::Config(_)) {
-                    self.emulation.on_event(&event);
-                }
-                self.renderer.on_event(&event, &self.cfg);
-
-                match event {
-                    NesEvent::Config(ConfigEvent::InputBindings) => {
-                        self.input_bindings = InputBindings::from_input_config(&self.cfg.input);
+                match &event {
+                    NesEvent::Config(event) => {
+                        let Config {
+                            deck,
+                            emulation,
+                            audio,
+                            renderer,
+                            input,
+                        } = &mut self.cfg;
+                        match event {
+                            ConfigEvent::ActionBindings(bindings) => {
+                                input.action_bindings = bindings.clone();
+                                self.input_bindings = InputBindings::from_input_config(input);
+                            }
+                            ConfigEvent::ActionBindingSet((action, set_input, binding)) => {
+                                input.set_binding(*action, *set_input, *binding);
+                                self.input_bindings.insert(*set_input, *action);
+                            }
+                            ConfigEvent::ActionBindingClear(clear_input) => {
+                                input.clear_binding(*clear_input);
+                                self.input_bindings.remove(clear_input);
+                            }
+                            ConfigEvent::AlwaysOnTop(always_on_top) => {
+                                renderer.always_on_top = *always_on_top;
+                            }
+                            ConfigEvent::ApuChannelEnabled((channel, enabled)) => {
+                                deck.channels_enabled[*channel as usize] = *enabled;
+                            }
+                            ConfigEvent::ApuChannelsEnabled(enabled) => {
+                                deck.channels_enabled = *enabled;
+                            }
+                            ConfigEvent::AudioBuffer(buffer_size) => {
+                                audio.buffer_size = *buffer_size;
+                            }
+                            ConfigEvent::AudioEnabled(enabled) => audio.enabled = *enabled,
+                            ConfigEvent::AudioLatency(latency) => audio.latency = *latency,
+                            ConfigEvent::AutoLoad(enabled) => emulation.auto_load = *enabled,
+                            ConfigEvent::AutoSave(enabled) => emulation.auto_save = *enabled,
+                            ConfigEvent::AutoSaveInterval(interval) => {
+                                emulation.auto_save_interval = *interval;
+                            }
+                            ConfigEvent::ConcurrentDpad(enabled) => deck.concurrent_dpad = *enabled,
+                            ConfigEvent::CycleAccurate(enabled) => deck.cycle_accurate = *enabled,
+                            ConfigEvent::DarkTheme(enabled) => renderer.dark_theme = *enabled,
+                            ConfigEvent::EmbedViewports(embed) => renderer.embed_viewports = *embed,
+                            ConfigEvent::FourPlayer(four_player) => deck.four_player = *four_player,
+                            ConfigEvent::Fullscreen(fullscreen) => {
+                                renderer.fullscreen = *fullscreen
+                            }
+                            ConfigEvent::GamepadAssign((player, uuid)) => {
+                                input.assign_gamepad(*player, *uuid);
+                                if let Some(name) = self.gamepads.gamepad_name_by_uuid(uuid) {
+                                    self.tx.event(UiEvent::Message((
+                                        MessageType::Info,
+                                        format!("Assigned gamepad `{name}` to player {player:?}.",),
+                                    )));
+                                }
+                            }
+                            ConfigEvent::GamepadUnassign(player) => {
+                                if let Some(uuid) = input.unassign_gamepad(*player) {
+                                    if let Some(name) = self.gamepads.gamepad_name_by_uuid(&uuid) {
+                                        self.tx.event(UiEvent::Message((
+                                            MessageType::Info,
+                                            format!("Unassigned gamepad `{name}` from player {player:?}."),
+                                        )));
+                                    }
+                                }
+                            }
+                            ConfigEvent::GamepadAssignments(assignments) => {
+                                input.gamepad_assignments = *assignments;
+                            }
+                            ConfigEvent::GenieCodeAdded(genie_code) => {
+                                deck.genie_codes.push(genie_code.clone());
+                            }
+                            ConfigEvent::GenieCodeClear => deck.genie_codes.clear(),
+                            ConfigEvent::GenieCodeRemoved(code) => {
+                                deck.genie_codes.retain(|genie| genie.code() != code);
+                            }
+                            ConfigEvent::HideOverscan(hide) => renderer.hide_overscan = *hide,
+                            ConfigEvent::MapperRevisions(revs) => deck.mapper_revisions = *revs,
+                            ConfigEvent::RamState(ram_state) => deck.ram_state = *ram_state,
+                            ConfigEvent::RecentRomsClear => renderer.recent_roms.clear(),
+                            ConfigEvent::Region(region) => deck.region = *region,
+                            ConfigEvent::RewindEnabled(enabled) => emulation.rewind = *enabled,
+                            ConfigEvent::RewindInterval(interval) => {
+                                emulation.rewind_interval = *interval;
+                            }
+                            ConfigEvent::RewindSeconds(seconds) => {
+                                emulation.rewind_seconds = *seconds;
+                            }
+                            ConfigEvent::RunAhead(run_ahead) => emulation.run_ahead = *run_ahead,
+                            ConfigEvent::SaveSlot(slot) => emulation.save_slot = *slot,
+                            ConfigEvent::Scale(scale) => renderer.scale = *scale,
+                            ConfigEvent::Shader(shader) => renderer.shader = *shader,
+                            ConfigEvent::ShowMenubar(show) => renderer.show_menubar = *show,
+                            ConfigEvent::ShowMessages(show) => renderer.show_messages = *show,
+                            ConfigEvent::Speed(speed) => emulation.speed = *speed,
+                            ConfigEvent::VideoFilter(filter) => deck.filter = *filter,
+                            ConfigEvent::ZapperConnected(connected) => deck.zapper = *connected,
+                        }
                     }
                     NesEvent::Renderer(RendererEvent::RequestRedraw { viewport_id, when }) => {
-                        if let Some(window_id) = self.renderer.window_id_for_viewport(viewport_id) {
+                        if let Some(window_id) = self.renderer.window_id_for_viewport(*viewport_id)
+                        {
                             self.repaint_times.insert(
                                 window_id,
                                 self.repaint_times
                                     .get(&window_id)
-                                    .map_or(when, |last| (*last).min(when)),
+                                    .map_or(*when, |last| (*last).min(*when)),
                             );
                         }
                     }
                     NesEvent::Ui(event) => self.on_ui_event(event),
                     _ => (),
                 }
+
+                // Only wake emulation of relevant events
+                if matches!(event, NesEvent::Emulation(_) | NesEvent::Config(_)) {
+                    self.emulation.on_event(&event);
+                }
+                self.renderer.on_event(&event, &self.cfg);
             }
             Event::LoopExiting => {
                 if let Err(err) = self.renderer.save(&self.cfg) {
@@ -497,13 +618,13 @@ impl Running {
         }
     }
 
-    pub fn on_ui_event(&mut self, event: UiEvent) {
+    pub fn on_ui_event(&mut self, event: &UiEvent) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
         match event {
-            UiEvent::Message((ty, msg)) => self.renderer.add_message(ty, msg),
-            UiEvent::Error(err) => self.renderer.on_error(anyhow!(err)),
+            UiEvent::Message((ty, msg)) => self.renderer.add_message(*ty, msg),
+            UiEvent::Error(err) => self.renderer.on_error(anyhow!(err.clone())),
             UiEvent::LoadRomDialog => {
                 match open_file_dialog(
                     "Load ROM",
@@ -513,12 +634,12 @@ impl Running {
                 ) {
                     Ok(maybe_path) => {
                         if let Some(path) = maybe_path {
-                            self.nes_event(EmulationEvent::LoadRomPath(path));
+                            self.event(EmulationEvent::LoadRomPath(path));
                         }
                     }
                     Err(err) => {
                         error!("failed top open rom dialog: {err:?}");
-                        self.nes_event(UiEvent::Error("failed to open rom dialog".to_string()));
+                        self.event(UiEvent::Error("failed to open rom dialog".to_string()));
                     }
                 }
             }
@@ -531,19 +652,19 @@ impl Running {
                 ) {
                     Ok(maybe_path) => {
                         if let Some(path) = maybe_path {
-                            self.nes_event(EmulationEvent::LoadReplayPath(path));
+                            self.event(EmulationEvent::LoadReplayPath(path));
                         }
                     }
                     Err(err) => {
                         error!("failed top open replay dialog: {err:?}");
-                        self.nes_event(UiEvent::Error("failed to open replay dialog".to_string()));
+                        self.event(UiEvent::Error("failed to open replay dialog".to_string()));
                     }
                 }
             }
             UiEvent::FileDialogCancelled => {
                 if self.renderer.rom_loaded() {
                     self.run_state = RunState::Running;
-                    self.nes_event(EmulationEvent::RunState(self.run_state));
+                    self.event(EmulationEvent::RunState(self.run_state));
                 }
             }
             UiEvent::UpdateAvailable(_) | UiEvent::Terminate => (),
@@ -551,7 +672,7 @@ impl Running {
     }
 
     /// Trigger a custom event.
-    pub fn nes_event(&mut self, event: impl Into<NesEvent>) {
+    pub fn event(&mut self, event: impl Into<NesEvent>) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
@@ -561,7 +682,7 @@ impl Running {
         self.emulation.on_event(&event);
         self.renderer.on_event(&event, &self.cfg);
         match event {
-            NesEvent::Ui(event) => self.on_ui_event(event),
+            NesEvent::Ui(event) => self.on_ui_event(&event),
             NesEvent::Emulation(EmulationEvent::LoadRomPath(path)) => {
                 if let Ok(path) = path.canonicalize() {
                     self.cfg.renderer.recent_roms.insert(path);
@@ -683,49 +804,49 @@ impl Running {
             let is_root_window = Some(window_id) == self.renderer.root_window_id();
             match action {
                 Action::Ui(ui_state) if released => match ui_state {
-                    Ui::Quit => self.tx.nes_event(UiEvent::Terminate),
+                    Ui::Quit => self.tx.event(UiEvent::Terminate),
                     Ui::TogglePause => {
                         if is_root_window && self.renderer.rom_loaded() {
                             self.run_state = match self.run_state {
                                 RunState::Running => RunState::ManuallyPaused,
                                 RunState::ManuallyPaused | RunState::Paused => RunState::Running,
                             };
-                            self.nes_event(EmulationEvent::RunState(self.run_state));
+                            self.event(EmulationEvent::RunState(self.run_state));
                         }
                     }
                     Ui::LoadRom => {
                         if self.renderer.rom_loaded() {
                             self.run_state = RunState::Paused;
-                            self.nes_event(EmulationEvent::RunState(self.run_state));
+                            self.event(EmulationEvent::RunState(self.run_state));
                         }
                         // NOTE: Due to some platforms file dialogs blocking the event loop,
                         // loading requires a round-trip in order for the above pause to
                         // get processed.
-                        self.tx.nes_event(UiEvent::LoadRomDialog);
+                        self.tx.event(UiEvent::LoadRomDialog);
                     }
                     Ui::UnloadRom => {
                         if self.renderer.rom_loaded() {
-                            self.nes_event(EmulationEvent::UnloadRom);
+                            self.event(EmulationEvent::UnloadRom);
                         }
                     }
                     Ui::LoadReplay => {
                         if self.renderer.rom_loaded() {
                             self.run_state = RunState::Paused;
-                            self.nes_event(EmulationEvent::RunState(self.run_state));
+                            self.event(EmulationEvent::RunState(self.run_state));
                             // NOTE: Due to some platforms file dialogs blocking the event loop,
                             // loading requires a round-trip in order for the above pause to
                             // get processed.
-                            self.tx.nes_event(UiEvent::LoadReplayDialog);
+                            self.tx.event(UiEvent::LoadReplayDialog);
                         }
                     }
                 },
-                Action::Menu(menu) if released => self.nes_event(RendererEvent::Menu(menu)),
+                Action::Menu(menu) if released => self.event(RendererEvent::Menu(menu)),
                 Action::Feature(feature) if is_root_window => match feature {
                     Feature::ToggleReplayRecording if released => {
                         if platform::supports(platform::Feature::Filesystem) {
                             if self.renderer.rom_loaded() {
                                 self.replay_recording = !self.replay_recording;
-                                self.nes_event(EmulationEvent::ReplayRecord(self.replay_recording));
+                                self.event(EmulationEvent::ReplayRecord(self.replay_recording));
                             }
                         } else {
                             self.renderer.add_message(
@@ -738,7 +859,7 @@ impl Running {
                         if platform::supports(platform::Feature::Filesystem) {
                             if self.renderer.rom_loaded() {
                                 self.audio_recording = !self.audio_recording;
-                                self.nes_event(EmulationEvent::AudioRecord(self.audio_recording));
+                                self.event(EmulationEvent::AudioRecord(self.audio_recording));
                             }
                         } else {
                             self.renderer.add_message(
@@ -750,7 +871,7 @@ impl Running {
                     Feature::TakeScreenshot if released => {
                         if platform::supports(platform::Feature::Filesystem) {
                             if self.renderer.rom_loaded() {
-                                self.nes_event(EmulationEvent::Screenshot);
+                                self.event(EmulationEvent::Screenshot);
                             }
                         } else {
                             self.renderer.add_message(
@@ -763,13 +884,13 @@ impl Running {
                         if !self.rewinding {
                             if repeat {
                                 self.rewinding = true;
-                                self.nes_event(EmulationEvent::Rewinding(self.rewinding));
+                                self.event(EmulationEvent::Rewinding(self.rewinding));
                             } else if released {
-                                self.nes_event(EmulationEvent::InstantRewind);
+                                self.event(EmulationEvent::InstantRewind);
                             }
                         } else if released {
                             self.rewinding = false;
-                            self.nes_event(EmulationEvent::Rewinding(self.rewinding));
+                            self.event(EmulationEvent::Rewinding(self.rewinding));
                         }
                     }
                     _ => (),
@@ -794,31 +915,31 @@ impl Running {
                     }
                     Setting::ToggleAudio if released => {
                         self.cfg.audio.enabled = !self.cfg.audio.enabled;
-                        self.nes_event(ConfigEvent::AudioEnabled(self.cfg.audio.enabled));
+                        self.event(ConfigEvent::AudioEnabled(self.cfg.audio.enabled));
                     }
                     Setting::ToggleMenubar if released => {
                         self.cfg.renderer.show_menubar = !self.cfg.renderer.show_menubar;
-                        self.nes_event(RendererEvent::ShowMenubar(self.cfg.renderer.show_menubar));
+                        self.event(RendererEvent::ShowMenubar(self.cfg.renderer.show_menubar));
                     }
                     Setting::IncrementScale if released => {
                         let scale = self.cfg.renderer.scale;
                         let new_scale = self.cfg.increment_scale();
                         if scale != new_scale {
-                            self.nes_event(RendererEvent::ScaleChanged);
+                            self.event(ConfigEvent::Scale(new_scale));
                         }
                     }
                     Setting::DecrementScale if released => {
                         let scale = self.cfg.renderer.scale;
                         let new_scale = self.cfg.decrement_scale();
                         if scale != new_scale {
-                            self.nes_event(RendererEvent::ScaleChanged);
+                            self.event(ConfigEvent::Scale(new_scale));
                         }
                     }
                     Setting::IncrementSpeed if released => {
                         let speed = self.cfg.emulation.speed;
                         let new_speed = self.cfg.increment_speed();
                         if speed != new_speed {
-                            self.nes_event(ConfigEvent::Speed(self.cfg.emulation.speed));
+                            self.event(ConfigEvent::Speed(self.cfg.emulation.speed));
                             self.renderer.add_message(
                                 MessageType::Info,
                                 format!("Increased Emulation Speed to {new_speed}"),
@@ -829,7 +950,7 @@ impl Running {
                         let speed = self.cfg.emulation.speed;
                         let new_speed = self.cfg.decrement_speed();
                         if speed != new_speed {
-                            self.nes_event(ConfigEvent::Speed(self.cfg.emulation.speed));
+                            self.event(ConfigEvent::Speed(self.cfg.emulation.speed));
                             self.renderer.add_message(
                                 MessageType::Info,
                                 format!("Decreased Emulation Speed to {new_speed}"),
@@ -843,7 +964,7 @@ impl Running {
                         let speed = self.cfg.emulation.speed;
                         if speed != new_speed {
                             self.cfg.emulation.speed = new_speed;
-                            self.nes_event(ConfigEvent::Speed(self.cfg.emulation.speed));
+                            self.event(ConfigEvent::Speed(self.cfg.emulation.speed));
                             if new_speed == 2.0 {
                                 self.renderer
                                     .add_message(MessageType::Info, "Fast forwarding");
@@ -854,10 +975,10 @@ impl Running {
                 },
                 Action::Deck(action) => match action {
                     DeckAction::Reset(kind) if released => {
-                        self.nes_event(EmulationEvent::Reset(kind));
+                        self.event(EmulationEvent::Reset(kind));
                     }
                     DeckAction::Joypad((player, button)) if !repeat && is_root_window => {
-                        self.nes_event(EmulationEvent::Joypad((player, button, state)));
+                        self.event(EmulationEvent::Joypad((player, button, state)));
                     }
                     // Handled by `gui` module
                     DeckAction::ZapperAim(_)
@@ -881,7 +1002,7 @@ impl Running {
                     }
                     DeckAction::SaveState if released && is_root_window => {
                         if platform::supports(platform::Feature::Storage) {
-                            self.nes_event(EmulationEvent::SaveState(self.cfg.emulation.save_slot));
+                            self.event(EmulationEvent::SaveState(self.cfg.emulation.save_slot));
                         } else {
                             self.renderer.add_message(
                                 MessageType::Warn,
@@ -891,7 +1012,7 @@ impl Running {
                     }
                     DeckAction::LoadState if released && is_root_window => {
                         if platform::supports(platform::Feature::Storage) {
-                            self.nes_event(EmulationEvent::LoadState(self.cfg.emulation.save_slot));
+                            self.event(EmulationEvent::LoadState(self.cfg.emulation.save_slot));
                         } else {
                             self.renderer.add_message(
                                 MessageType::Warn,
@@ -902,16 +1023,14 @@ impl Running {
                     DeckAction::ToggleApuChannel(channel) if released => {
                         self.cfg.deck.channels_enabled[channel as usize] =
                             !self.cfg.deck.channels_enabled[channel as usize];
-                        self.nes_event(ConfigEvent::ApuChannelEnabled((
+                        self.event(ConfigEvent::ApuChannelEnabled((
                             channel,
                             self.cfg.deck.channels_enabled[channel as usize],
                         )));
                     }
                     DeckAction::MapperRevision(rev) if released => {
                         self.cfg.deck.mapper_revisions.set(rev);
-                        self.nes_event(ConfigEvent::MapperRevisions(
-                            self.cfg.deck.mapper_revisions,
-                        ));
+                        self.event(ConfigEvent::MapperRevisions(self.cfg.deck.mapper_revisions));
                         self.renderer.add_message(
                             MessageType::Info,
                             format!("Changed Mapper Revision to {rev}"),
@@ -919,7 +1038,7 @@ impl Running {
                     }
                     DeckAction::SetNesRegion(region) if released => {
                         self.cfg.deck.region = region;
-                        self.nes_event(ConfigEvent::Region(self.cfg.deck.region));
+                        self.event(ConfigEvent::Region(self.cfg.deck.region));
                         self.renderer.add_message(
                             MessageType::Info,
                             format!("Changed NES Region to {region:?}"),
@@ -932,19 +1051,23 @@ impl Running {
                             filter
                         };
                         self.cfg.deck.filter = filter;
-                        self.nes_event(ConfigEvent::VideoFilter(filter));
+                        self.event(ConfigEvent::VideoFilter(filter));
                     }
                     _ => (),
                 },
                 Action::Debug(action) => match action {
                     Debug::Toggle(kind) if released => {
-                        self.renderer.add_message(
-                            MessageType::Warn,
-                            format!("{kind:?} is not implemented yet"),
-                        );
+                        if matches!(kind, Debugger::Ppu) {
+                            self.event(RendererEvent::Menu(Menu::PpuViewer));
+                        } else {
+                            self.renderer.add_message(
+                                MessageType::Warn,
+                                format!("{kind:?} is not implemented yet"),
+                            );
+                        }
                     }
                     Debug::Step(step) if (released | repeat) && is_root_window => {
-                        self.nes_event(EmulationEvent::DebugStep(step));
+                        self.event(EmulationEvent::DebugStep(step));
                     }
                     _ => (),
                 },

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -493,7 +493,7 @@ impl Running {
                         } = &mut self.cfg;
                         match event {
                             ConfigEvent::ActionBindings(bindings) => {
-                                input.action_bindings = bindings.clone();
+                                input.action_bindings.clone_from(bindings);
                                 self.input_bindings = InputBindings::from_input_config(input);
                             }
                             ConfigEvent::ActionBindingSet((action, set_input, binding)) => {

--- a/tetanes/src/nes/renderer/gui.rs
+++ b/tetanes/src/nes/renderer/gui.rs
@@ -10,7 +10,10 @@ use crate::{
         renderer::{
             gui::{
                 keybinds::Keybinds,
-                lib::{cursor_to_zapper, input_down, ShortcutText, ToggleValue, ViewportOptions},
+                lib::{
+                    cursor_to_zapper, input_down, ShortcutText, ShowShortcut, ToggleValue,
+                    ViewportOptions,
+                },
                 ppu_viewer::PpuViewer,
                 preferences::Preferences,
             },
@@ -285,7 +288,7 @@ impl Gui {
         region.aspect_ratio()
     }
 
-    pub fn prepare(&mut self, gamepads: &Gamepads, cfg: &Config) {
+    pub fn update(&mut self, gamepads: &Gamepads, cfg: &Config) {
         self.cfg = cfg.clone();
         self.preferences.prepare(&self.cfg);
         self.keybinds.prepare(gamepads, &self.cfg);
@@ -676,7 +679,13 @@ impl Gui {
 
             // icon: # in a square
             ui.menu_button("󾠬 Save Slot...", |ui| {
-                Preferences::save_slot_radio(tx, ui, cfg.emulation.save_slot, cfg);
+                Preferences::save_slot_radio(
+                    tx,
+                    ui,
+                    cfg.emulation.save_slot,
+                    cfg,
+                    ShowShortcut::Yes,
+                );
             });
         }
 

--- a/tetanes/src/nes/renderer/gui.rs
+++ b/tetanes/src/nes/renderer/gui.rs
@@ -288,10 +288,11 @@ impl Gui {
         region.aspect_ratio()
     }
 
-    pub fn update(&mut self, gamepads: &Gamepads, cfg: &Config) {
+    pub fn prepare(&mut self, gamepads: &Gamepads, cfg: &Config) {
         self.cfg = cfg.clone();
         self.preferences.prepare(&self.cfg);
         self.keybinds.prepare(gamepads, &self.cfg);
+        self.ppu_viewer.prepare(&self.cfg);
     }
 
     /// Create the UI.

--- a/tetanes/src/nes/renderer/gui/keybinds.rs
+++ b/tetanes/src/nes/renderer/gui/keybinds.rs
@@ -1,0 +1,531 @@
+use crate::nes::{
+    action::Action,
+    config::Config,
+    event::{ConfigEvent, NesEventProxy},
+    input::{Gamepads, Input},
+    renderer::gui::lib::ViewportOptions,
+};
+use egui::{Align2, Button, CentralPanel, Context, Grid, ScrollArea, Ui, Vec2, ViewportClass};
+use parking_lot::RwLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tetanes_core::input::Player;
+use tracing::warn;
+use uuid::Uuid;
+use winit::event::ElementState;
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Tab {
+    #[default]
+    Shortcuts,
+    Joypad(Player),
+}
+
+#[derive(Debug)]
+#[must_use]
+pub struct State {
+    tx: NesEventProxy,
+    tab: Tab,
+    pending_input: Option<PendingInput>,
+    gamepad_unassign_confirm: Option<(Player, Player, Uuid)>,
+}
+
+#[derive(Debug)]
+#[must_use]
+pub struct Keybinds {
+    open: Arc<AtomicBool>,
+    state: Arc<RwLock<State>>,
+    resources: Option<(Config, GamepadState)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingInput {
+    action: Action,
+    input: Option<Input>,
+    binding: usize,
+    conflict: Option<Action>,
+}
+
+#[derive(Debug)]
+#[must_use]
+pub struct GamepadState {
+    input_events: Vec<(Input, ElementState)>,
+    connected: Option<Vec<ConnectedGamepad>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[must_use]
+pub struct ConnectedGamepad {
+    pub uuid: Uuid,
+    pub name: String,
+    pub assignment: Option<Player>,
+}
+
+impl Keybinds {
+    pub fn new(tx: NesEventProxy) -> Self {
+        Self {
+            open: Arc::new(AtomicBool::new(false)),
+            state: Arc::new(RwLock::new(State {
+                tx,
+                tab: Tab::default(),
+                pending_input: None,
+                gamepad_unassign_confirm: None,
+            })),
+            resources: None,
+        }
+    }
+
+    pub fn wants_input(&self) -> bool {
+        let state = self.state.read();
+        state.pending_input.is_some() || state.gamepad_unassign_confirm.is_some()
+    }
+
+    pub fn open(&self) -> bool {
+        self.open.load(Ordering::Acquire)
+    }
+
+    pub fn set_open(&self, open: bool) {
+        self.open.store(open, Ordering::Release);
+    }
+
+    pub fn toggle_open(&self) {
+        let _ = self
+            .open
+            .fetch_update(Ordering::Release, Ordering::Acquire, |open| Some(!open));
+    }
+
+    pub fn prepare(&mut self, gamepads: &Gamepads, cfg: &Config) {
+        self.resources = Some((
+            cfg.clone(),
+            GamepadState {
+                input_events: gamepads
+                    .events()
+                    .filter_map(|event| gamepads.input_from_event(event, cfg))
+                    .collect::<Vec<_>>(),
+                connected: gamepads.list().map(|gamepad_list| {
+                    gamepad_list
+                        .map(|(_, gamepad)| {
+                            let uuid = Gamepads::create_uuid(&gamepad);
+                            ConnectedGamepad {
+                                uuid,
+                                name: gamepad.name().to_string(),
+                                assignment: cfg.input.gamepad_assignment(&uuid),
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                }),
+            },
+        ));
+    }
+
+    pub fn show(&mut self, ctx: &Context, opts: ViewportOptions) {
+        if !self.open() {
+            let mut state = self.state.write();
+            state.pending_input = None;
+            state.gamepad_unassign_confirm = None;
+            return;
+        }
+
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let title = "Keybinds";
+        let mut viewport_builder = egui::ViewportBuilder::default().with_title(title);
+        if opts.always_on_top {
+            viewport_builder = viewport_builder.with_always_on_top();
+        }
+
+        let open = Arc::clone(&self.open);
+        let state = Arc::clone(&self.state);
+        let Some((cfg, gamepad_state)) = self.resources.take() else {
+            warn!("Keybinds::prepare was not called with required resources");
+            return;
+        };
+
+        ctx.show_viewport_deferred(
+            egui::ViewportId::from_hash_of("keybinds"),
+            viewport_builder,
+            move |ctx, class| {
+                if class == ViewportClass::Embedded {
+                    let mut window_open = open.load(Ordering::Acquire);
+                    egui::Window::new("Keybinds")
+                        .open(&mut window_open)
+                        .show(ctx, |ui| {
+                            state.write().ui(ui, opts.enabled, &cfg, &gamepad_state);
+                        });
+                    open.store(window_open, Ordering::Release);
+                } else {
+                    CentralPanel::default().show(ctx, |ui| {
+                        state.write().ui(ui, opts.enabled, &cfg, &gamepad_state);
+                    });
+                    if ctx.input(|i| i.viewport().close_requested()) {
+                        open.store(false, Ordering::Release);
+                    }
+                }
+            },
+        );
+    }
+}
+
+impl State {
+    fn ui(&mut self, ui: &mut Ui, enabled: bool, cfg: &Config, gamepad_state: &GamepadState) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        self.show_set_keybind_window(ui.ctx(), cfg, &gamepad_state.input_events);
+        self.show_gamepad_unassign_window(ui.ctx());
+
+        ui.add_enabled_ui(enabled, |ui| {
+            ui.horizontal(|ui| {
+                ui.selectable_value(&mut self.tab, Tab::Shortcuts, "Shortcuts");
+                ui.selectable_value(&mut self.tab, Tab::Joypad(Player::One), "Player1");
+                ui.selectable_value(&mut self.tab, Tab::Joypad(Player::Two), "Player2");
+                ui.selectable_value(&mut self.tab, Tab::Joypad(Player::Three), "Player3");
+                ui.selectable_value(&mut self.tab, Tab::Joypad(Player::Four), "Player4");
+            });
+
+            ui.separator();
+
+            match self.tab {
+                Tab::Shortcuts => self.list(ui, None, cfg, gamepad_state.connected.as_deref()),
+                Tab::Joypad(player) => {
+                    self.list(ui, Some(player), cfg, gamepad_state.connected.as_deref())
+                }
+            }
+        });
+    }
+
+    fn list(
+        &mut self,
+        ui: &mut Ui,
+        player: Option<Player>,
+        cfg: &Config,
+        connected_gamepads: Option<&[ConnectedGamepad]>,
+    ) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        if let Some(player) = player {
+            self.player_gamepad_combo(ui, player, connected_gamepads);
+
+            ui.separator();
+        }
+
+        ScrollArea::both().show(ui, |ui| {
+            ui.set_width(ui.available_width()); // Pushes scrollbar to the right of the window
+
+            let grid = Grid::new("keybind_list")
+                .num_columns(3)
+                .spacing([40.0, 6.0]);
+            grid.show(ui, |ui| {
+                ui.heading("Action");
+                ui.heading("Binding #1");
+                ui.heading("Binding #2");
+                ui.heading("Binding #3");
+                ui.end_row();
+
+                let keybinds = match player {
+                    None => &cfg.input.shortcuts,
+                    Some(player) => &cfg.input.joypads[player as usize],
+                };
+                let mut clear_bind = None;
+                for (action, bind) in keybinds {
+                    ui.strong(action.to_string());
+                    for (slot, input) in bind.bindings.iter().enumerate() {
+                        let button = Button::new(input.map(Input::fmt).unwrap_or_default())
+                            .min_size(Vec2::new(100.0, 0.0));
+                        let res = ui
+                            .add(button)
+                            .on_hover_text("Click to set. Right-click to unset.");
+                        if res.clicked() {
+                            self.pending_input = Some(PendingInput {
+                                action: *action,
+                                input: None,
+                                binding: slot,
+                                conflict: None,
+                            });
+                        } else if res.secondary_clicked() {
+                            if let Some(input) = input {
+                                clear_bind = Some(input)
+                            }
+                        }
+                    }
+                    ui.end_row();
+                }
+                if let Some(input) = clear_bind.take() {
+                    self.tx.event(ConfigEvent::ActionBindingClear(*input));
+                }
+            });
+        });
+    }
+
+    fn player_gamepad_combo(
+        &mut self,
+        ui: &mut Ui,
+        player: Player,
+        connected_gamepads: Option<&[ConnectedGamepad]>,
+    ) {
+        ui.horizontal(|ui| {
+            ui.strong("Assigned Gamepad:");
+
+            let unassigned = "Unassigned".to_string();
+            match connected_gamepads {
+                Some(gamepads) => {
+                    if gamepads.is_empty() {
+                        ui.set_enabled(false);
+                        let combo = egui::ComboBox::from_id_source("assigned_gamepad")
+                            .selected_text("No Gamepads Connected");
+                        combo.show_ui(ui, |_| {});
+                    } else {
+                        let mut assigned = gamepads
+                            .iter()
+                            .find(|gamepad| gamepad.assignment == Some(player));
+                        let previous_assigned = assigned;
+                        let combo = egui::ComboBox::from_id_source("assigned_gamepad")
+                            .selected_text(
+                                assigned
+                                    .as_ref()
+                                    .map_or(&unassigned, |assignment| &assignment.name),
+                            );
+                        combo.show_ui(ui, |ui| {
+                            ui.selectable_value(&mut assigned, None, unassigned);
+                            for assignment in gamepads {
+                                ui.selectable_value(
+                                    &mut assigned,
+                                    Some(assignment),
+                                    &assignment.name,
+                                );
+                            }
+                        });
+                        if previous_assigned != assigned {
+                            match &assigned {
+                                Some(gamepad) => {
+                                    match assigned.as_ref().and_then(|gamepad| gamepad.assignment) {
+                                        Some(player) => {
+                                            self.gamepad_unassign_confirm =
+                                                Some((player, player, gamepad.uuid));
+                                        }
+                                        None => {
+                                            self.tx.event(ConfigEvent::GamepadAssign((
+                                                player,
+                                                gamepad.uuid,
+                                            )));
+                                        }
+                                    }
+                                }
+                                None => self.tx.event(ConfigEvent::GamepadUnassign(player)),
+                            }
+                        }
+                    }
+                }
+                None => {
+                    ui.set_enabled(false);
+                    let combo = egui::ComboBox::from_id_source("assigned_gamepad")
+                        .selected_text("Gamepads not supported");
+                    combo.show_ui(ui, |_| {});
+                }
+            }
+        });
+    }
+
+    pub fn show_set_keybind_window(
+        &mut self,
+        ctx: &Context,
+        cfg: &Config,
+        gamepad_events: &[(Input, ElementState)],
+    ) {
+        if self.pending_input.is_none() {
+            return;
+        }
+
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let mut set_keybind_open = self.pending_input.is_some();
+        let res = egui::Window::new("Set Keybind")
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .open(&mut set_keybind_open)
+            .show(ctx, |ui| self.set_keybind(ui, cfg, gamepad_events));
+        if let Some(ref res) = res {
+            // Force on-top focus when embedded
+            if set_keybind_open {
+                ctx.move_to_top(res.response.layer_id);
+                res.response.request_focus();
+            } else {
+                ctx.memory_mut(|m| m.surrender_focus(res.response.id));
+            }
+        }
+        if !set_keybind_open {
+            self.pending_input = None;
+        }
+    }
+
+    pub fn set_keybind(
+        &mut self,
+        ui: &mut Ui,
+        cfg: &Config,
+        gamepad_events: &[(Input, ElementState)],
+    ) {
+        let Some(PendingInput {
+            action,
+            binding,
+            mut input,
+            mut conflict,
+            ..
+        }) = self.pending_input
+        else {
+            return;
+        };
+
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        if let Some(action) = conflict {
+            ui.label(format!("Conflict with {action}."));
+            ui.horizontal(|ui| {
+                if ui.button("Overwrite").clicked() {
+                    conflict = None;
+                }
+                if ui.button("Cancel").clicked() {
+                    self.pending_input = None;
+                    input = None;
+                }
+            });
+        } else {
+            ui.label(format!(
+                "Press any key on your keyboard or controller to set a new binding for {action}.",
+            ));
+        }
+
+        match input {
+            Some(input) => {
+                if conflict.is_none() {
+                    self.pending_input = None;
+                    self.tx
+                        .event(ConfigEvent::ActionBindingSet((action, input, binding)));
+                }
+            }
+            None => {
+                if let Some(keybind) = &mut self.pending_input {
+                    let input = ui.input(|i| {
+                        use egui::Event;
+
+                        // Find first released key/button event
+                        for event in &i.events {
+                            match *event {
+                                Event::Key {
+                                    physical_key: Some(key),
+                                    pressed: true,
+                                    modifiers,
+                                    ..
+                                } => {
+                                    // TODO: Ignore unsupported key mappings for now as egui supports less
+                                    // overall than winit
+                                    return Input::try_from((key, modifiers)).ok();
+                                }
+                                Event::PointerButton {
+                                    button,
+                                    pressed: true,
+                                    ..
+                                } => {
+                                    return Some(Input::from(button));
+                                }
+                                _ => (),
+                            }
+                        }
+                        for (input, state) in gamepad_events {
+                            if *state == ElementState::Released {
+                                return Some(*input);
+                            }
+                        }
+                        None
+                    });
+
+                    if let Some(input) = input {
+                        keybind.input = Some(input);
+                        let binds = cfg
+                            .input
+                            .shortcuts
+                            .iter()
+                            .chain(cfg.input.joypads.iter().flatten());
+                        for (action, bind) in binds {
+                            if bind
+                                .bindings
+                                .iter()
+                                .any(|b| b == &Some(input) && *action != keybind.action)
+                            {
+                                keybind.conflict = Some(*action);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn show_gamepad_unassign_window(&mut self, ctx: &Context) {
+        if self.gamepad_unassign_confirm.is_none() {
+            return;
+        }
+
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let mut gamepad_unassign_open = self.gamepad_unassign_confirm.is_some();
+        let res = egui::Window::new("Unassign Gamepad")
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .open(&mut gamepad_unassign_open)
+            .show(ctx, |ui| self.gamepad_unassign_confirm(ui));
+        if let Some(ref res) = res {
+            // Force on-top focus when embedded
+            if gamepad_unassign_open {
+                ctx.move_to_top(res.response.layer_id);
+                res.response.request_focus();
+            } else {
+                ctx.memory_mut(|m| m.surrender_focus(res.response.id));
+            }
+        }
+        if !gamepad_unassign_open {
+            self.gamepad_unassign_confirm = None;
+        }
+    }
+
+    fn gamepad_unassign_confirm(&mut self, ui: &mut Ui) {
+        if let Some((existing_player, new_player, uuid)) = self.gamepad_unassign_confirm {
+            ui.label(format!("Unassign gamepad from Player {existing_player}?"));
+            ui.horizontal(|ui| {
+                if ui.button("Yes").clicked() {
+                    self.tx.event(ConfigEvent::GamepadUnassign(existing_player));
+                    self.tx
+                        .event(ConfigEvent::GamepadAssign((new_player, uuid)));
+                    self.gamepad_unassign_confirm = None;
+                }
+                if ui.button("Cancel").clicked() {
+                    self.gamepad_unassign_confirm = None;
+                }
+            });
+        }
+    }
+
+    pub fn action_input(action: impl Into<Action>, cfg: &Config) -> Option<Input> {
+        let action = action.into();
+        cfg.input
+            .shortcuts
+            .get(&action)
+            .or_else(|| {
+                cfg.input
+                    .joypads
+                    .iter()
+                    .map(|bind| bind.get(&action))
+                    .next()
+                    .flatten()
+            })
+            .and_then(|bind| bind.bindings[0])
+    }
+}

--- a/tetanes/src/nes/renderer/gui/keybinds.rs
+++ b/tetanes/src/nes/renderer/gui/keybinds.rs
@@ -548,20 +548,4 @@ impl State {
             });
         }
     }
-
-    pub fn action_input(action: impl Into<Action>, cfg: &Config) -> Option<Input> {
-        let action = action.into();
-        cfg.input
-            .shortcuts
-            .get(&action)
-            .or_else(|| {
-                cfg.input
-                    .joypads
-                    .iter()
-                    .map(|bind| bind.get(&action))
-                    .next()
-                    .flatten()
-            })
-            .and_then(|bind| bind.bindings[0])
-    }
 }

--- a/tetanes/src/nes/renderer/gui/lib.rs
+++ b/tetanes/src/nes/renderer/gui/lib.rs
@@ -20,6 +20,21 @@ pub struct ViewportOptions {
     pub always_on_top: bool,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum ShowShortcut {
+    Yes,
+    No,
+}
+
+impl ShowShortcut {
+    pub fn then<T>(&self, f: impl FnOnce() -> T) -> Option<T> {
+        match self {
+            Self::Yes => Some(f()),
+            Self::No => None,
+        }
+    }
+}
+
 pub trait ShortcutText<'a>
 where
     Self: Sized + 'a,

--- a/tetanes/src/nes/renderer/gui/lib.rs
+++ b/tetanes/src/nes/renderer/gui/lib.rs
@@ -1,0 +1,501 @@
+use crate::nes::{
+    config::Config,
+    input::{Gamepads, Input},
+};
+use egui::{
+    Align, Checkbox, Context, Key, KeyboardShortcut, Layout, Modifiers, PointerButton, Pos2, Rect,
+    Response, RichText, Ui, Widget, WidgetText,
+};
+use std::ops::{Deref, DerefMut};
+use tetanes_core::ppu::Ppu;
+use winit::{
+    event::{ElementState, MouseButton},
+    keyboard::{KeyCode, ModifiersState},
+};
+
+#[derive(Debug, Copy, Clone)]
+#[must_use]
+pub struct ViewportOptions {
+    pub enabled: bool,
+    pub always_on_top: bool,
+}
+
+pub trait ShortcutText<'a>
+where
+    Self: Sized + 'a,
+{
+    fn shortcut_text(self, shortcut_text: impl Into<RichText>) -> ShortcutWidget<'a, Self> {
+        ShortcutWidget {
+            inner: self,
+            shortcut_text: shortcut_text.into(),
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+pub fn cursor_to_zapper(x: f32, y: f32, rect: Rect) -> Option<Pos2> {
+    let width = Ppu::WIDTH as f32;
+    let height = Ppu::HEIGHT as f32;
+    // Normalize x/y to 0..=1 and scale to PPU dimensions
+    let x = ((x - rect.min.x) / rect.width()) * width;
+    let y = ((y - rect.min.y) / rect.height()) * height;
+    ((0.0..width).contains(&x) && (0.0..height).contains(&y)).then_some(Pos2::new(x, y))
+}
+
+pub fn input_down(ui: &mut Ui, gamepads: Option<&Gamepads>, cfg: &Config, input: Input) -> bool {
+    ui.input_mut(|i| match input {
+        Input::Key(keycode, modifier_state) => key_from_keycode(keycode).map_or(false, |key| {
+            let modifiers = modifiers_from_modifiers_state(modifier_state);
+            i.key_down(key) && i.modifiers == modifiers
+        }),
+        Input::Button(player, button) => cfg
+            .input
+            .gamepad_assigned_to(player)
+            .and_then(|uuid| gamepads.map(|g| g.gamepad_by_uuid(&uuid)))
+            .flatten()
+            .map_or(false, |g| g.is_pressed(button)),
+        Input::Mouse(mouse_button) => pointer_button_from_mouse(mouse_button)
+            .map_or(false, |pointer| i.pointer.button_down(pointer)),
+        Input::Axis(player, axis, direction) => cfg
+            .input
+            .gamepad_assigned_to(player)
+            .and_then(|uuid| gamepads.map(|g| g.gamepad_by_uuid(&uuid)))
+            .flatten()
+            .and_then(|g| g.axis_data(axis).map(|data| data.value()))
+            .map_or(false, |value| {
+                let (dir, state) = Gamepads::axis_state(value);
+                dir == Some(direction) && state == ElementState::Pressed
+            }),
+    })
+}
+
+#[must_use]
+pub struct ShortcutWidget<'a, T> {
+    inner: T,
+    shortcut_text: RichText,
+    phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, T> Deref for ShortcutWidget<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, T> DerefMut for ShortcutWidget<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<'a, T> Widget for ShortcutWidget<'a, T>
+where
+    T: Widget,
+{
+    fn ui(self, ui: &mut Ui) -> Response {
+        if self.shortcut_text.is_empty() {
+            self.inner.ui(ui)
+        } else {
+            ui.horizontal(|ui| {
+                let res = self.inner.ui(ui);
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    ui.weak(self.shortcut_text);
+                });
+                res
+            })
+            .inner
+        }
+    }
+}
+
+#[must_use]
+pub struct ToggleValue<'a> {
+    selected: &'a mut bool,
+    text: WidgetText,
+}
+
+impl<'a> ToggleValue<'a> {
+    pub fn new(selected: &'a mut bool, text: impl Into<WidgetText>) -> Self {
+        Self {
+            selected,
+            text: text.into(),
+        }
+    }
+}
+
+impl<'a> Widget for ToggleValue<'a> {
+    fn ui(self, ui: &mut Ui) -> Response {
+        let mut res = ui.selectable_label(*self.selected, self.text);
+        if res.clicked() {
+            *self.selected = !*self.selected;
+            res.mark_changed();
+        }
+        res
+    }
+}
+
+#[must_use]
+pub struct RadioValue<'a, T> {
+    current_value: &'a mut T,
+    alternative: T,
+    text: WidgetText,
+}
+
+impl<'a, T: PartialEq> RadioValue<'a, T> {
+    pub fn new(current_value: &'a mut T, alternative: T, text: impl Into<WidgetText>) -> Self {
+        Self {
+            current_value,
+            alternative,
+            text: text.into(),
+        }
+    }
+}
+
+impl<'a, T: PartialEq> Widget for RadioValue<'a, T> {
+    fn ui(self, ui: &mut Ui) -> Response {
+        let mut res = ui.radio(*self.current_value == self.alternative, self.text);
+        if res.clicked() && *self.current_value != self.alternative {
+            *self.current_value = self.alternative;
+            res.mark_changed();
+        }
+        res
+    }
+}
+
+impl<'a> ShortcutText<'a> for Checkbox<'a> {}
+impl<'a> ShortcutText<'a> for ToggleValue<'a> {}
+impl<'a, T> ShortcutText<'a> for RadioValue<'a, T> {}
+
+impl TryFrom<Input> for KeyboardShortcut {
+    type Error = ();
+
+    fn try_from(val: Input) -> Result<Self, Self::Error> {
+        if let Input::Key(keycode, modifier_state) = val {
+            Ok(KeyboardShortcut {
+                logical_key: key_from_keycode(keycode).ok_or(())?,
+                modifiers: modifiers_from_modifiers_state(modifier_state),
+            })
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<(Key, Modifiers)> for Input {
+    type Error = ();
+
+    fn try_from((key, modifiers): (Key, Modifiers)) -> Result<Self, Self::Error> {
+        let keycode = keycode_from_key(key).ok_or(())?;
+        let modifiers = modifiers_state_from_modifiers(modifiers);
+        Ok(Input::Key(keycode, modifiers))
+    }
+}
+
+impl From<PointerButton> for Input {
+    fn from(button: PointerButton) -> Self {
+        Input::Mouse(mouse_button_from_pointer(button))
+    }
+}
+
+pub const fn key_from_keycode(keycode: KeyCode) -> Option<Key> {
+    Some(match keycode {
+        KeyCode::ArrowDown => Key::ArrowDown,
+        KeyCode::ArrowLeft => Key::ArrowLeft,
+        KeyCode::ArrowRight => Key::ArrowRight,
+        KeyCode::ArrowUp => Key::ArrowUp,
+
+        KeyCode::Escape => Key::Escape,
+        KeyCode::Tab => Key::Tab,
+        KeyCode::Backspace => Key::Backspace,
+        KeyCode::Enter | KeyCode::NumpadEnter => Key::Enter,
+
+        KeyCode::Insert => Key::Insert,
+        KeyCode::Delete => Key::Delete,
+        KeyCode::Home => Key::Home,
+        KeyCode::End => Key::End,
+        KeyCode::PageUp => Key::PageUp,
+        KeyCode::PageDown => Key::PageDown,
+
+        // Punctuation
+        KeyCode::Space => Key::Space,
+        KeyCode::Comma => Key::Comma,
+        KeyCode::Period => Key::Period,
+        KeyCode::Semicolon => Key::Semicolon,
+        KeyCode::Backslash => Key::Backslash,
+        KeyCode::Slash | KeyCode::NumpadDivide => Key::Slash,
+        KeyCode::BracketLeft => Key::OpenBracket,
+        KeyCode::BracketRight => Key::CloseBracket,
+        KeyCode::Backquote => Key::Backtick,
+
+        KeyCode::Cut => Key::Cut,
+        KeyCode::Copy => Key::Copy,
+        KeyCode::Paste => Key::Paste,
+        KeyCode::Minus | KeyCode::NumpadSubtract => Key::Minus,
+        KeyCode::NumpadAdd => Key::Plus,
+        KeyCode::Equal => Key::Equals,
+
+        KeyCode::Digit0 | KeyCode::Numpad0 => Key::Num0,
+        KeyCode::Digit1 | KeyCode::Numpad1 => Key::Num1,
+        KeyCode::Digit2 | KeyCode::Numpad2 => Key::Num2,
+        KeyCode::Digit3 | KeyCode::Numpad3 => Key::Num3,
+        KeyCode::Digit4 | KeyCode::Numpad4 => Key::Num4,
+        KeyCode::Digit5 | KeyCode::Numpad5 => Key::Num5,
+        KeyCode::Digit6 | KeyCode::Numpad6 => Key::Num6,
+        KeyCode::Digit7 | KeyCode::Numpad7 => Key::Num7,
+        KeyCode::Digit8 | KeyCode::Numpad8 => Key::Num8,
+        KeyCode::Digit9 | KeyCode::Numpad9 => Key::Num9,
+
+        KeyCode::KeyA => Key::A,
+        KeyCode::KeyB => Key::B,
+        KeyCode::KeyC => Key::C,
+        KeyCode::KeyD => Key::D,
+        KeyCode::KeyE => Key::E,
+        KeyCode::KeyF => Key::F,
+        KeyCode::KeyG => Key::G,
+        KeyCode::KeyH => Key::H,
+        KeyCode::KeyI => Key::I,
+        KeyCode::KeyJ => Key::J,
+        KeyCode::KeyK => Key::K,
+        KeyCode::KeyL => Key::L,
+        KeyCode::KeyM => Key::M,
+        KeyCode::KeyN => Key::N,
+        KeyCode::KeyO => Key::O,
+        KeyCode::KeyP => Key::P,
+        KeyCode::KeyQ => Key::Q,
+        KeyCode::KeyR => Key::R,
+        KeyCode::KeyS => Key::S,
+        KeyCode::KeyT => Key::T,
+        KeyCode::KeyU => Key::U,
+        KeyCode::KeyV => Key::V,
+        KeyCode::KeyW => Key::W,
+        KeyCode::KeyX => Key::X,
+        KeyCode::KeyY => Key::Y,
+        KeyCode::KeyZ => Key::Z,
+
+        KeyCode::F1 => Key::F1,
+        KeyCode::F2 => Key::F2,
+        KeyCode::F3 => Key::F3,
+        KeyCode::F4 => Key::F4,
+        KeyCode::F5 => Key::F5,
+        KeyCode::F6 => Key::F6,
+        KeyCode::F7 => Key::F7,
+        KeyCode::F8 => Key::F8,
+        KeyCode::F9 => Key::F9,
+        KeyCode::F10 => Key::F10,
+        KeyCode::F11 => Key::F11,
+        KeyCode::F12 => Key::F12,
+        KeyCode::F13 => Key::F13,
+        KeyCode::F14 => Key::F14,
+        KeyCode::F15 => Key::F15,
+        KeyCode::F16 => Key::F16,
+        KeyCode::F17 => Key::F17,
+        KeyCode::F18 => Key::F18,
+        KeyCode::F19 => Key::F19,
+        KeyCode::F20 => Key::F20,
+        KeyCode::F21 => Key::F21,
+        KeyCode::F22 => Key::F22,
+        KeyCode::F23 => Key::F23,
+        KeyCode::F24 => Key::F24,
+        KeyCode::F25 => Key::F25,
+        KeyCode::F26 => Key::F26,
+        KeyCode::F27 => Key::F27,
+        KeyCode::F28 => Key::F28,
+        KeyCode::F29 => Key::F29,
+        KeyCode::F30 => Key::F30,
+        KeyCode::F31 => Key::F31,
+        KeyCode::F32 => Key::F32,
+        KeyCode::F33 => Key::F33,
+        KeyCode::F34 => Key::F34,
+        KeyCode::F35 => Key::F35,
+
+        _ => {
+            return None;
+        }
+    })
+}
+
+pub const fn keycode_from_key(key: Key) -> Option<KeyCode> {
+    Some(match key {
+        Key::ArrowDown => KeyCode::ArrowDown,
+        Key::ArrowLeft => KeyCode::ArrowLeft,
+        Key::ArrowRight => KeyCode::ArrowRight,
+        Key::ArrowUp => KeyCode::ArrowUp,
+
+        Key::Escape => KeyCode::Escape,
+        Key::Tab => KeyCode::Tab,
+        Key::Backspace => KeyCode::Backspace,
+        Key::Enter => KeyCode::Enter,
+
+        Key::Insert => KeyCode::Insert,
+        Key::Delete => KeyCode::Delete,
+        Key::Home => KeyCode::Home,
+        Key::End => KeyCode::End,
+        Key::PageUp => KeyCode::PageUp,
+        Key::PageDown => KeyCode::PageDown,
+
+        // Punctuation
+        Key::Space => KeyCode::Space,
+        Key::Comma => KeyCode::Comma,
+        Key::Period => KeyCode::Period,
+        Key::Semicolon => KeyCode::Semicolon,
+        Key::Backslash => KeyCode::Backslash,
+        Key::Slash => KeyCode::Slash,
+        Key::OpenBracket => KeyCode::BracketLeft,
+        Key::CloseBracket => KeyCode::BracketRight,
+
+        Key::Cut => KeyCode::Cut,
+        Key::Copy => KeyCode::Copy,
+        Key::Paste => KeyCode::Paste,
+        Key::Minus => KeyCode::Minus,
+        Key::Plus => KeyCode::NumpadAdd,
+        Key::Equals => KeyCode::Equal,
+
+        Key::Num0 => KeyCode::Digit0,
+        Key::Num1 => KeyCode::Digit1,
+        Key::Num2 => KeyCode::Digit2,
+        Key::Num3 => KeyCode::Digit3,
+        Key::Num4 => KeyCode::Digit4,
+        Key::Num5 => KeyCode::Digit5,
+        Key::Num6 => KeyCode::Digit6,
+        Key::Num7 => KeyCode::Digit7,
+        Key::Num8 => KeyCode::Digit8,
+        Key::Num9 => KeyCode::Digit9,
+
+        Key::A => KeyCode::KeyA,
+        Key::B => KeyCode::KeyB,
+        Key::C => KeyCode::KeyC,
+        Key::D => KeyCode::KeyD,
+        Key::E => KeyCode::KeyE,
+        Key::F => KeyCode::KeyF,
+        Key::G => KeyCode::KeyG,
+        Key::H => KeyCode::KeyH,
+        Key::I => KeyCode::KeyI,
+        Key::J => KeyCode::KeyJ,
+        Key::K => KeyCode::KeyK,
+        Key::L => KeyCode::KeyL,
+        Key::M => KeyCode::KeyM,
+        Key::N => KeyCode::KeyN,
+        Key::O => KeyCode::KeyO,
+        Key::P => KeyCode::KeyP,
+        Key::Q => KeyCode::KeyQ,
+        Key::R => KeyCode::KeyR,
+        Key::S => KeyCode::KeyS,
+        Key::T => KeyCode::KeyT,
+        Key::U => KeyCode::KeyU,
+        Key::V => KeyCode::KeyV,
+        Key::W => KeyCode::KeyW,
+        Key::X => KeyCode::KeyX,
+        Key::Y => KeyCode::KeyY,
+        Key::Z => KeyCode::KeyZ,
+
+        Key::F1 => KeyCode::F1,
+        Key::F2 => KeyCode::F2,
+        Key::F3 => KeyCode::F3,
+        Key::F4 => KeyCode::F4,
+        Key::F5 => KeyCode::F5,
+        Key::F6 => KeyCode::F6,
+        Key::F7 => KeyCode::F7,
+        Key::F8 => KeyCode::F8,
+        Key::F9 => KeyCode::F9,
+        Key::F10 => KeyCode::F10,
+        Key::F11 => KeyCode::F11,
+        Key::F12 => KeyCode::F12,
+        Key::F13 => KeyCode::F13,
+        Key::F14 => KeyCode::F14,
+        Key::F15 => KeyCode::F15,
+        Key::F16 => KeyCode::F16,
+        Key::F17 => KeyCode::F17,
+        Key::F18 => KeyCode::F18,
+        Key::F19 => KeyCode::F19,
+        Key::F20 => KeyCode::F20,
+        Key::F21 => KeyCode::F21,
+        Key::F22 => KeyCode::F22,
+        Key::F23 => KeyCode::F23,
+        Key::F24 => KeyCode::F24,
+        Key::F25 => KeyCode::F25,
+        Key::F26 => KeyCode::F26,
+        Key::F27 => KeyCode::F27,
+        Key::F28 => KeyCode::F28,
+        Key::F29 => KeyCode::F29,
+        Key::F30 => KeyCode::F30,
+        Key::F31 => KeyCode::F31,
+        Key::F32 => KeyCode::F32,
+        Key::F33 => KeyCode::F33,
+        Key::F34 => KeyCode::F34,
+        Key::F35 => KeyCode::F35,
+
+        _ => return None,
+    })
+}
+
+pub fn modifiers_from_modifiers_state(modifier_state: ModifiersState) -> Modifiers {
+    Modifiers {
+        alt: modifier_state.alt_key(),
+        ctrl: modifier_state.control_key(),
+        shift: modifier_state.shift_key(),
+        #[cfg(target_os = "macos")]
+        mac_cmd: modifier_state.super_key(),
+        #[cfg(not(target_os = "macos"))]
+        mac_cmd: false,
+        #[cfg(target_os = "macos")]
+        command: modifier_state.super_key(),
+        #[cfg(not(target_os = "macos"))]
+        command: modifier_state.control_key(),
+    }
+}
+
+pub fn modifiers_state_from_modifiers(modifiers: Modifiers) -> ModifiersState {
+    let mut modifiers_state = ModifiersState::empty();
+    if modifiers.shift {
+        modifiers_state |= ModifiersState::SHIFT;
+    }
+    if modifiers.ctrl {
+        modifiers_state |= ModifiersState::CONTROL;
+    }
+    if modifiers.alt {
+        modifiers_state |= ModifiersState::ALT;
+    }
+    #[cfg(target_os = "macos")]
+    if modifiers.mac_cmd {
+        modifiers_state |= ModifiersState::SUPER;
+    }
+    // TODO: egui doesn't seem to support SUPER on Windows/Linux
+    modifiers_state
+}
+
+pub const fn pointer_button_from_mouse(button: MouseButton) -> Option<PointerButton> {
+    Some(match button {
+        MouseButton::Left => PointerButton::Primary,
+        MouseButton::Right => PointerButton::Secondary,
+        MouseButton::Middle => PointerButton::Middle,
+        MouseButton::Back => PointerButton::Extra1,
+        MouseButton::Forward => PointerButton::Extra2,
+        MouseButton::Other(_) => return None,
+    })
+}
+
+pub const fn mouse_button_from_pointer(button: PointerButton) -> MouseButton {
+    match button {
+        PointerButton::Primary => MouseButton::Left,
+        PointerButton::Secondary => MouseButton::Right,
+        PointerButton::Middle => MouseButton::Middle,
+        PointerButton::Extra1 => MouseButton::Back,
+        PointerButton::Extra2 => MouseButton::Forward,
+    }
+}
+
+pub fn screen_center(ctx: &Context) -> Option<Pos2> {
+    ctx.input(|i| {
+        let outer_rect = i.viewport().outer_rect?;
+        let size = outer_rect.size();
+        let monitor_size = i.viewport().monitor_size?;
+        if 1.0 < monitor_size.x && 1.0 < monitor_size.y {
+            let x = (monitor_size.x - size.x) / 2.0;
+            let y = (monitor_size.y - size.y) / 2.0;
+            Some(Pos2::new(x, y))
+        } else {
+            None
+        }
+    })
+}

--- a/tetanes/src/nes/renderer/gui/ppu_viewer.rs
+++ b/tetanes/src/nes/renderer/gui/ppu_viewer.rs
@@ -1,0 +1,126 @@
+use crate::nes::{event::NesEventProxy, renderer::gui::lib::ViewportOptions};
+use egui::{CentralPanel, Context, Ui, ViewportClass};
+use parking_lot::RwLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+#[derive(Debug)]
+#[must_use]
+pub struct State {
+    tx: NesEventProxy,
+    tab: Tab,
+}
+
+#[derive(Debug)]
+#[must_use]
+pub struct PpuViewer {
+    open: Arc<AtomicBool>,
+    state: Arc<RwLock<State>>,
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Tab {
+    #[default]
+    Nametables,
+    Chr,
+    Sprites,
+    Palette,
+}
+
+impl PpuViewer {
+    pub fn new(tx: NesEventProxy) -> Self {
+        Self {
+            open: Arc::new(AtomicBool::new(false)),
+            state: Arc::new(RwLock::new(State {
+                tx,
+                tab: Tab::default(),
+            })),
+        }
+    }
+
+    pub fn open(&self) -> bool {
+        self.open.load(Ordering::Acquire)
+    }
+
+    pub fn set_open(&self, open: bool) {
+        self.open.store(open, Ordering::Release);
+    }
+
+    pub fn toggle_open(&self) {
+        let _ = self
+            .open
+            .fetch_update(Ordering::Release, Ordering::Acquire, |open| Some(!open));
+    }
+
+    pub fn show(&mut self, ctx: &Context, opts: ViewportOptions) {
+        if !self.open.load(Ordering::Relaxed) {
+            return;
+        }
+
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let title = "PPU Viewer";
+        let mut viewport_builder = egui::ViewportBuilder::default().with_title(title);
+        if opts.always_on_top {
+            viewport_builder = viewport_builder.with_always_on_top();
+        }
+
+        let open = Arc::clone(&self.open);
+        let state = Arc::clone(&self.state);
+
+        ctx.show_viewport_deferred(
+            egui::ViewportId::from_hash_of("ppu_viewer"),
+            viewport_builder,
+            move |ctx, class| {
+                if class == ViewportClass::Embedded {
+                    let mut window_open = open.load(Ordering::Acquire);
+                    egui::Window::new(title)
+                        .open(&mut window_open)
+                        .show(ctx, |ui| state.write().ui(ui, opts.enabled));
+                    open.store(window_open, Ordering::Release);
+                } else {
+                    CentralPanel::default().show(ctx, |ui| state.write().ui(ui, opts.enabled));
+                    if ctx.input(|i| i.viewport().close_requested()) {
+                        open.store(false, Ordering::Release);
+                    }
+                }
+            },
+        );
+    }
+}
+
+impl State {
+    fn ui(&mut self, ui: &mut Ui, enabled: bool) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        ui.add_enabled_ui(enabled, |ui| {
+            ui.horizontal(|ui| {
+                ui.selectable_value(&mut self.tab, Tab::Nametables, "Nametables");
+                ui.selectable_value(&mut self.tab, Tab::Chr, "CHR");
+                ui.selectable_value(&mut self.tab, Tab::Sprites, "Sprites");
+                ui.selectable_value(&mut self.tab, Tab::Palette, "Palette");
+            });
+
+            ui.separator();
+
+            match self.tab {
+                Tab::Nametables => self.nametables(ui),
+                Tab::Chr => self.chr(ui),
+                Tab::Sprites => self.sprites(ui),
+                Tab::Palette => self.palette(ui),
+            }
+        });
+    }
+
+    fn nametables(&mut self, ui: &mut Ui) {}
+
+    fn chr(&mut self, ui: &mut Ui) {}
+
+    fn sprites(&mut self, ui: &mut Ui) {}
+
+    fn palette(&mut self, ui: &mut Ui) {}
+}

--- a/tetanes/src/nes/renderer/gui/ppu_viewer.rs
+++ b/tetanes/src/nes/renderer/gui/ppu_viewer.rs
@@ -9,7 +9,7 @@ use std::sync::{
 #[derive(Debug)]
 #[must_use]
 pub struct State {
-    tx: NesEventProxy,
+    _tx: NesEventProxy,
     tab: Tab,
 }
 
@@ -34,7 +34,7 @@ impl PpuViewer {
         Self {
             open: Arc::new(AtomicBool::new(false)),
             state: Arc::new(RwLock::new(State {
-                tx,
+                _tx: tx,
                 tab: Tab::default(),
             })),
         }
@@ -116,11 +116,11 @@ impl State {
         });
     }
 
-    fn nametables(&mut self, ui: &mut Ui) {}
+    fn nametables(&mut self, _ui: &mut Ui) {}
 
-    fn chr(&mut self, ui: &mut Ui) {}
+    fn chr(&mut self, _ui: &mut Ui) {}
 
-    fn sprites(&mut self, ui: &mut Ui) {}
+    fn sprites(&mut self, _ui: &mut Ui) {}
 
-    fn palette(&mut self, ui: &mut Ui) {}
+    fn palette(&mut self, _ui: &mut Ui) {}
 }

--- a/tetanes/src/nes/renderer/gui/ppu_viewer.rs
+++ b/tetanes/src/nes/renderer/gui/ppu_viewer.rs
@@ -1,10 +1,12 @@
-use crate::nes::{event::NesEventProxy, renderer::gui::lib::ViewportOptions};
+use crate::nes::{config::Config, event::NesEventProxy, renderer::gui::lib::ViewportOptions};
+use cfg_if::cfg_if;
 use egui::{CentralPanel, Context, Ui, ViewportClass};
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
+use tracing::warn;
 
 #[derive(Debug)]
 #[must_use]
@@ -17,7 +19,8 @@ pub struct State {
 #[must_use]
 pub struct PpuViewer {
     open: Arc<AtomicBool>,
-    state: Arc<RwLock<State>>,
+    state: Arc<Mutex<State>>,
+    resources: Option<Config>,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
@@ -30,13 +33,16 @@ pub enum Tab {
 }
 
 impl PpuViewer {
+    const TITLE: &'static str = "PPU Viewer";
+
     pub fn new(tx: NesEventProxy) -> Self {
         Self {
             open: Arc::new(AtomicBool::new(false)),
-            state: Arc::new(RwLock::new(State {
+            state: Arc::new(Mutex::new(State {
                 _tx: tx,
                 tab: Tab::default(),
             })),
+            resources: None,
         }
     }
 
@@ -54,6 +60,10 @@ impl PpuViewer {
             .fetch_update(Ordering::Release, Ordering::Acquire, |open| Some(!open));
     }
 
+    pub fn prepare(&mut self, cfg: &Config) {
+        self.resources = Some(cfg.clone());
+    }
+
     pub fn show(&mut self, ctx: &Context, opts: ViewportOptions) {
         if !self.open.load(Ordering::Relaxed) {
             return;
@@ -62,38 +72,57 @@ impl PpuViewer {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        let title = "PPU Viewer";
-        let mut viewport_builder = egui::ViewportBuilder::default().with_title(title);
+        let mut viewport_builder = egui::ViewportBuilder::default().with_title(Self::TITLE);
         if opts.always_on_top {
             viewport_builder = viewport_builder.with_always_on_top();
         }
 
         let open = Arc::clone(&self.open);
         let state = Arc::clone(&self.state);
+        let Some(cfg) = self.resources.take() else {
+            warn!("PpuViewer::prepare was not called with required resources");
+            return;
+        };
 
-        ctx.show_viewport_deferred(
-            egui::ViewportId::from_hash_of("ppu_viewer"),
-            viewport_builder,
-            move |ctx, class| {
-                if class == ViewportClass::Embedded {
-                    let mut window_open = open.load(Ordering::Acquire);
-                    egui::Window::new(title)
-                        .open(&mut window_open)
-                        .show(ctx, |ui| state.write().ui(ui, opts.enabled));
-                    open.store(window_open, Ordering::Release);
-                } else {
-                    CentralPanel::default().show(ctx, |ui| state.write().ui(ui, opts.enabled));
-                    if ctx.input(|i| i.viewport().close_requested()) {
-                        open.store(false, Ordering::Release);
-                    }
+        let viewport_id = egui::ViewportId::from_hash_of("ppu_viewer");
+        fn viewport_cb(
+            ctx: &Context,
+            class: ViewportClass,
+            open: &Arc<AtomicBool>,
+            enabled: bool,
+            state: &Arc<Mutex<State>>,
+            cfg: &Config,
+        ) {
+            if class == ViewportClass::Embedded {
+                let mut window_open = open.load(Ordering::Acquire);
+                egui::Window::new(PpuViewer::TITLE)
+                    .open(&mut window_open)
+                    .show(ctx, |ui| state.lock().ui(ui, enabled, cfg));
+                open.store(window_open, Ordering::Release);
+            } else {
+                CentralPanel::default().show(ctx, |ui| state.lock().ui(ui, enabled, cfg));
+                if ctx.input(|i| i.viewport().close_requested()) {
+                    open.store(false, Ordering::Release);
                 }
-            },
-        );
+            }
+        }
+
+        cfg_if! {
+            if #[cfg(target_arch = "wasm32")] {
+                ctx.show_viewport_immediate(viewport_id, viewport_builder, move |ctx, class| {
+                    viewport_cb(ctx, class, &open, opts.enabled, &state, &cfg);
+                });
+            } else {
+                ctx.show_viewport_deferred(viewport_id, viewport_builder, move |ctx, class| {
+                    viewport_cb(ctx, class, &open, opts.enabled, &state, &cfg);
+                });
+            }
+        }
     }
 }
 
 impl State {
-    fn ui(&mut self, ui: &mut Ui, enabled: bool) {
+    fn ui(&mut self, ui: &mut Ui, enabled: bool, _cfg: &Config) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 

--- a/tetanes/src/nes/renderer/gui/preferences.rs
+++ b/tetanes/src/nes/renderer/gui/preferences.rs
@@ -60,12 +60,6 @@ pub struct GenieEntry {
     error: Option<String>,
 }
 
-impl GenieEntry {
-    pub fn empty() -> Self {
-        Self::default()
-    }
-}
-
 impl Preferences {
     const TITLE: &'static str = "Preferences";
 

--- a/tetanes/src/nes/renderer/gui/preferences.rs
+++ b/tetanes/src/nes/renderer/gui/preferences.rs
@@ -1,0 +1,994 @@
+use crate::{
+    nes::{
+        config::{AudioConfig, Config, EmulationConfig, RendererConfig},
+        event::{ConfigEvent, EmulationEvent, NesEventProxy, UiEvent},
+        renderer::{
+            gui::{
+                lib::{RadioValue, ShortcutText, ViewportOptions},
+                Gui, MessageType,
+            },
+            shader::Shader,
+        },
+    },
+    platform,
+};
+use egui::{
+    Align, CentralPanel, Checkbox, Context, CursorIcon, DragValue, Grid, Key, Layout, ScrollArea,
+    Slider, TextEdit, Ui, Vec2, ViewportClass,
+};
+use parking_lot::RwLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tetanes_core::{
+    action::Action as DeckAction, apu::Channel, common::NesRegion,
+    control_deck::Config as DeckConfig, fs, genie::GenieCode, input::FourPlayer, mem::RamState,
+    time::Duration, video::VideoFilter,
+};
+use tracing::warn;
+
+#[derive(Debug)]
+#[must_use]
+pub struct State {
+    tx: NesEventProxy,
+    tab: Tab,
+    genie_entry: GenieEntry,
+}
+
+#[derive(Debug)]
+#[must_use]
+pub struct Preferences {
+    open: Arc<AtomicBool>,
+    state: Arc<RwLock<State>>,
+    resources: Option<Config>,
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Tab {
+    #[default]
+    Emulation,
+    Audio,
+    Video,
+    Input,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct GenieEntry {
+    code: String,
+    error: Option<String>,
+}
+
+impl GenieEntry {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+impl Preferences {
+    pub fn new(tx: NesEventProxy) -> Self {
+        Self {
+            open: Arc::new(AtomicBool::new(false)),
+            state: Arc::new(RwLock::new(State {
+                tx,
+                tab: Tab::default(),
+                genie_entry: GenieEntry::default(),
+            })),
+            resources: None,
+        }
+    }
+
+    pub fn open(&self) -> bool {
+        self.open.load(Ordering::Acquire)
+    }
+
+    pub fn set_open(&self, open: bool) {
+        self.open.store(open, Ordering::Release);
+    }
+
+    pub fn toggle_open(&self) {
+        let _ = self
+            .open
+            .fetch_update(Ordering::Release, Ordering::Acquire, |open| Some(!open));
+    }
+
+    pub fn prepare(&mut self, cfg: &Config) {
+        self.resources = Some(cfg.clone());
+    }
+
+    pub fn show(&mut self, ctx: &Context, opts: ViewportOptions) {
+        if !self.open() {
+            return;
+        }
+
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let title = "Preferences";
+        let mut viewport_builder = egui::ViewportBuilder::default().with_title(title);
+        if opts.always_on_top {
+            viewport_builder = viewport_builder.with_always_on_top();
+        }
+
+        let open = Arc::clone(&self.open);
+        let state = Arc::clone(&self.state);
+        let Some(cfg) = self.resources.take() else {
+            warn!("Preferences::prepare was not called with required resources");
+            return;
+        };
+
+        ctx.show_viewport_deferred(
+            egui::ViewportId::from_hash_of("preferences"),
+            viewport_builder,
+            move |ctx, class| {
+                if class == ViewportClass::Embedded {
+                    let mut window_open = open.load(Ordering::Acquire);
+                    egui::Window::new(title)
+                        .open(&mut window_open)
+                        .show(ctx, |ui| state.write().ui(ui, opts.enabled, &cfg));
+                    open.store(window_open, Ordering::Release);
+                } else {
+                    CentralPanel::default()
+                        .show(ctx, |ui| state.write().ui(ui, opts.enabled, &cfg));
+                    if ctx.input(|i| i.viewport().close_requested()) {
+                        open.store(false, Ordering::Release);
+                    }
+                }
+            },
+        );
+    }
+
+    pub fn show_genie_codes_entry(&mut self, ui: &mut Ui, cfg: &Config) {
+        self.state.write().genie_codes_entry(ui, cfg);
+    }
+
+    pub fn genie_codes_list(tx: &NesEventProxy, ui: &mut Ui, cfg: &Config, scroll: bool) {
+        if !cfg.deck.genie_codes.is_empty() {
+            ui.vertical(|ui| {
+                ui.horizontal(|ui| {
+                    ui.strong("Current Genie Codes:");
+                    if ui.button("Clear All").clicked() {
+                        tx.event(ConfigEvent::GenieCodeClear);
+                    }
+                });
+
+                let render_codes = |ui: &mut Ui, cfg: &Config| {
+                    ui.indent("current_genie_codes", |ui| {
+                        let grid = Grid::new("genie_codes").num_columns(2).spacing([40.0, 6.0]);
+                        grid.show(ui, |ui| {
+                            for genie in &cfg.deck.genie_codes {
+                                ui.label(genie.code());
+                                // icon: waste basket
+                                if ui.button("🗑").clicked() {
+                                    tx.event(ConfigEvent::GenieCodeRemoved(
+                                        genie.code().to_string(),
+                                    ));
+                                }
+                                ui.end_row();
+                            }
+                        });
+                    })
+                };
+                if scroll {
+                    ScrollArea::vertical().show(ui, |ui| {
+                        render_codes(ui, cfg);
+                    });
+                } else {
+                    render_codes(ui, cfg);
+                }
+            });
+        }
+    }
+
+    pub fn save_slot_radio(tx: &NesEventProxy, ui: &mut Ui, mut save_slot: u8, cfg: &Config) {
+        ui.vertical(|ui| {
+            for slot in 1..=4 {
+                let radio = RadioValue::new(&mut save_slot, slot, slot.to_string())
+                    .shortcut_text(cfg.shortcut(DeckAction::SetSaveSlot(slot)));
+                if ui.add(radio).changed() {
+                    tx.event(ConfigEvent::SaveSlot(save_slot));
+                }
+            }
+        });
+        ui.vertical(|ui| {
+            for slot in 5..=8 {
+                let radio = RadioValue::new(&mut save_slot, slot, slot.to_string())
+                    .shortcut_text(cfg.shortcut(DeckAction::SetSaveSlot(slot)));
+                if ui.add(radio).changed() {
+                    tx.event(ConfigEvent::SaveSlot(save_slot));
+                }
+            }
+        });
+    }
+
+    pub fn speed_slider(tx: &NesEventProxy, ui: &mut Ui, mut speed: f32) {
+        let slider = Slider::new(&mut speed, 0.25..=2.0)
+            .step_by(0.25)
+            .suffix("x");
+        let res = ui
+            .add(slider)
+            .on_hover_text("Adjust the speed of the NES emulation.");
+        if res.changed() {
+            tx.event(ConfigEvent::Speed(speed));
+        }
+    }
+
+    pub fn run_ahead_slider(tx: &NesEventProxy, ui: &mut Ui, mut run_ahead: usize) {
+        let slider = Slider::new(&mut run_ahead, 0..=4);
+        let res = ui
+            .add(slider)
+            .on_hover_text("Simulate a number of frames in the future to reduce input lag.");
+        if res.changed() {
+            tx.event(ConfigEvent::RunAhead(run_ahead));
+        }
+    }
+
+    pub fn cycle_accurate_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut cycle_accurate: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        let icon = (!shortcut.is_empty()).then_some("📐 ").unwrap_or_default();
+        let checkbox = Checkbox::new(&mut cycle_accurate, format!("{icon}Cycle Accurate"))
+            .shortcut_text(shortcut);
+        let res = ui
+            .add(checkbox)
+            .on_hover_text("Enables more accurate NES emulation at a slight cost in performance.");
+        if res.clicked() {
+            tx.event(ConfigEvent::CycleAccurate(cycle_accurate));
+        }
+    }
+
+    pub fn rewind_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut rewind: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        let icon = (!shortcut.is_empty()).then_some("🔄 ").unwrap_or_default();
+        let checkbox =
+            Checkbox::new(&mut rewind, format!("{icon}Enable Rewinding")).shortcut_text(shortcut);
+        let res = ui
+            .add(checkbox)
+            .on_hover_text("Enable instant and visual rewinding. Increases memory usage.");
+        if res.clicked() {
+            tx.event(ConfigEvent::RewindEnabled(rewind));
+        }
+    }
+
+    pub fn zapper_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut zapper: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        let icon = (!shortcut.is_empty()).then_some("🔫 ").unwrap_or_default();
+        let checkbox =
+            Checkbox::new(&mut zapper, format!("{icon}Enable Zapper Gun")).shortcut_text(shortcut);
+        let res = ui
+            .add(checkbox)
+            .on_hover_text("Enable the Zapper Light Gun for games that support it.");
+        if res.clicked() {
+            tx.event(ConfigEvent::ZapperConnected(zapper));
+        }
+    }
+
+    pub fn overscan_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut hide_overscan: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        let icon = (!shortcut.is_empty()).then_some("📺 ").unwrap_or_default();
+        let checkbox = Checkbox::new(&mut hide_overscan, format!("{icon}Hide Overscan"))
+            .shortcut_text(shortcut);
+        let res = ui.add(checkbox)
+            .on_hover_text("Traditional CRT displays would crop the top and bottom edges of the image. Disable this to show the overscan.");
+        if res.clicked() {
+            tx.event(ConfigEvent::HideOverscan(hide_overscan));
+        }
+    }
+
+    pub fn video_filter_radio(tx: &NesEventProxy, ui: &mut Ui, mut filter: VideoFilter) {
+        let previous_filter = filter;
+        ui.radio_value(&mut filter, VideoFilter::Pixellate, "Pixellate")
+            .on_hover_text("Basic pixel-perfect rendering");
+        ui.radio_value(&mut filter, VideoFilter::Ntsc, "Ntsc")
+            .on_hover_text(
+                "Emulate traditional NTSC rendering where chroma spills over into luma.",
+            );
+        if filter != previous_filter {
+            tx.event(ConfigEvent::VideoFilter(filter));
+        }
+    }
+
+    pub fn shader_radio(tx: &NesEventProxy, ui: &mut Ui, mut shader: Shader) {
+        let previous_shader = shader;
+        ui.radio_value(&mut shader, Shader::None, "None")
+            .on_hover_text("No shader.");
+        ui.radio_value(&mut shader, Shader::CrtEasymode, "CRT Easymode")
+            .on_hover_text("Emulate traditional CRT aperture grill masking.");
+        if shader != previous_shader {
+            tx.event(ConfigEvent::Shader(shader));
+        }
+    }
+
+    pub fn four_player_radio(tx: &NesEventProxy, ui: &mut Ui, mut four_player: FourPlayer) {
+        let previous_four_player = four_player;
+        ui.radio_value(&mut four_player, FourPlayer::Disabled, "Disabled");
+        ui.radio_value(&mut four_player, FourPlayer::FourScore, "Four Score")
+            .on_hover_text("Enable NES Four Score for games that support 4 players.");
+        ui.radio_value(&mut four_player, FourPlayer::Satellite, "Satellite")
+            .on_hover_text("Enable NES Satellite for games that support 4 players.");
+        if four_player != previous_four_player {
+            tx.event(ConfigEvent::FourPlayer(four_player));
+        }
+    }
+
+    pub fn nes_region_radio(tx: &NesEventProxy, ui: &mut Ui, mut region: NesRegion) {
+        let previous_region = region;
+        ui.radio_value(&mut region, NesRegion::Auto, "Auto")
+            .on_hover_text("Auto-detect region based on loaded ROM.");
+        ui.radio_value(&mut region, NesRegion::Ntsc, "NTSC")
+            .on_hover_text("Emulate NTSC timing and aspect-ratio.");
+        ui.radio_value(&mut region, NesRegion::Pal, "PAL")
+            .on_hover_text("Emulate PAL timing and aspect-ratio.");
+        ui.radio_value(&mut region, NesRegion::Dendy, "Dendy")
+            .on_hover_text("Emulate Dendy timing and aspect-ratio.");
+        if region != previous_region {
+            tx.event(ConfigEvent::Region(region));
+        }
+    }
+
+    pub fn ram_state_radio(tx: &NesEventProxy, ui: &mut Ui, mut ram_state: RamState) {
+        let previous_ram_state = ram_state;
+        ui.radio_value(&mut ram_state, RamState::AllZeros, "All 0x00")
+            .on_hover_text("Clear startup RAM to all zeroes for predictable emulation.");
+        ui.radio_value(&mut ram_state, RamState::AllOnes, "All 0xFF")
+            .on_hover_text("Clear startup RAM to all ones for predictable emulation.");
+        ui.radio_value(&mut ram_state, RamState::Random, "Random")
+            .on_hover_text("Randomize startup RAM, which some games use as a basic RNG seed.");
+        if ram_state != previous_ram_state {
+            tx.event(ConfigEvent::RamState(ram_state));
+        }
+    }
+
+    pub fn menubar_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut show_menubar: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        let icon = (!shortcut.is_empty()).then_some("☰ ").unwrap_or_default();
+        let checkbox = Checkbox::new(&mut show_menubar, format!("{icon}Show Menu Bar"))
+            .shortcut_text(shortcut);
+        let res = ui.add(checkbox).on_hover_text("Show the menu bar.");
+        if res.clicked() {
+            tx.event(ConfigEvent::ShowMenubar(show_menubar));
+        }
+    }
+
+    pub fn messages_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut show_messages: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        // icon: document with text
+        let icon = (!shortcut.is_empty()).then_some("🖹 ").unwrap_or_default();
+        let checkbox = Checkbox::new(&mut show_messages, format!("{icon}Show Messages"))
+            .shortcut_text(shortcut);
+        let res = ui
+            .add(checkbox)
+            .on_hover_text("Show shortcut and emulator messages.");
+        if res.clicked() {
+            tx.event(ConfigEvent::ShowMessages(show_messages));
+        }
+    }
+
+    pub fn window_scale_radio(tx: &NesEventProxy, ui: &mut Ui, mut scale: f32) {
+        let previous_scale = scale;
+        ui.vertical(|ui| {
+            ui.radio_value(&mut scale, 1.0, "1x");
+            ui.radio_value(&mut scale, 2.0, "2x");
+            ui.radio_value(&mut scale, 3.0, "3x");
+        });
+        ui.vertical(|ui| {
+            ui.radio_value(&mut scale, 4.0, "4x");
+            ui.radio_value(&mut scale, 5.0, "5x");
+        });
+        if scale != previous_scale {
+            tx.event(ConfigEvent::Scale(scale));
+        }
+    }
+
+    pub fn fullscreen_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut fullscreen: bool,
+        shortcut: impl Into<String>,
+    ) {
+        let shortcut = shortcut.into();
+        // icon: screen
+        let icon = (!shortcut.is_empty()).then_some("🖵 ").unwrap_or_default();
+        let checkbox =
+            Checkbox::new(&mut fullscreen, format!("{icon}Fullscreen")).shortcut_text(shortcut);
+        if ui.add(checkbox).clicked() {
+            tx.event(ConfigEvent::Fullscreen(fullscreen));
+        }
+    }
+
+    pub fn embed_viewports_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        cfg: &Config,
+        shortcut: impl Into<String>,
+    ) {
+        if platform::supports(platform::Feature::Viewports) {
+            ui.add_enabled_ui(!cfg.renderer.fullscreen, |ui| {
+                let shortcut = shortcut.into();
+                // icon: maximize
+                let icon = (!shortcut.is_empty()).then_some("🗖 ").unwrap_or_default();
+                let mut embed_viewports = ui.ctx().embed_viewports();
+                let checkbox =
+                    Checkbox::new(&mut embed_viewports, format!("{icon}Embed Viewports"))
+                        .shortcut_text(shortcut);
+                let res = ui.add(checkbox).on_disabled_hover_text(
+                    "Non-embedded viewports are not supported while in fullscreen.",
+                );
+                if res.clicked() {
+                    ui.ctx().set_embed_viewports(embed_viewports);
+                    tx.event(ConfigEvent::EmbedViewports(embed_viewports));
+                }
+            });
+        }
+    }
+
+    pub fn always_on_top_checkbox(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut always_on_top: bool,
+        shortcut: impl Into<String>,
+    ) {
+        if platform::supports(platform::Feature::Viewports) {
+            let shortcut = shortcut.into();
+            let icon = (!shortcut.is_empty()).then_some("🔝 ").unwrap_or_default();
+            let checkbox = Checkbox::new(&mut always_on_top, format!("{icon}Always on Top"))
+                .shortcut_text(shortcut);
+            // FIXME: Currently when not using embeded viewports, toggling always on top from
+            // the preferences window will focus the primary window, potentially obscuring the
+            // preferences window
+            if ui.add(checkbox).clicked() {
+                tx.event(ConfigEvent::AlwaysOnTop(always_on_top));
+            }
+        }
+    }
+}
+
+impl State {
+    fn ui(&mut self, ui: &mut Ui, enabled: bool, cfg: &Config) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        ui.add_enabled_ui(enabled, |ui| {
+            ScrollArea::vertical().show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.selectable_value(&mut self.tab, Tab::Emulation, "Emulation");
+                    ui.selectable_value(&mut self.tab, Tab::Audio, "Audio");
+                    ui.selectable_value(&mut self.tab, Tab::Video, "Video");
+                    ui.selectable_value(&mut self.tab, Tab::Input, "Input");
+                });
+
+                ui.separator();
+
+                match self.tab {
+                    Tab::Emulation => self.emulation_tab(ui, cfg),
+                    Tab::Audio => Self::audio_tab(&self.tx, ui, cfg),
+                    Tab::Video => Self::video_tab(&self.tx, ui, cfg),
+                    Tab::Input => Self::input_tab(&self.tx, ui, cfg),
+                }
+
+                ui.separator();
+
+                ui.horizontal(|ui| {
+                    if ui.button("Restore Defaults").clicked() {
+                        ui.ctx().memory_mut(|mem| *mem = Default::default());
+
+                        // Inform all cfg updates
+                        let cfg = Config::default();
+                        let Config {
+                            deck,
+                            emulation,
+                            audio,
+                            renderer,
+                            input,
+                        } = cfg;
+                        let events = [
+                            ConfigEvent::ActionBindings(input.action_bindings),
+                            ConfigEvent::AlwaysOnTop(renderer.always_on_top),
+                            ConfigEvent::ApuChannelsEnabled(deck.channels_enabled),
+                            ConfigEvent::AudioBuffer(audio.buffer_size),
+                            ConfigEvent::AudioEnabled(audio.enabled),
+                            ConfigEvent::AudioLatency(audio.latency),
+                            ConfigEvent::AutoLoad(emulation.auto_load),
+                            ConfigEvent::AutoSave(emulation.auto_save),
+                            ConfigEvent::AutoSaveInterval(emulation.auto_save_interval),
+                            ConfigEvent::ConcurrentDpad(deck.concurrent_dpad),
+                            ConfigEvent::CycleAccurate(deck.cycle_accurate),
+                            ConfigEvent::DarkTheme(renderer.dark_theme),
+                            ConfigEvent::EmbedViewports(renderer.embed_viewports),
+                            ConfigEvent::FourPlayer(deck.four_player),
+                            ConfigEvent::Fullscreen(renderer.fullscreen),
+                            ConfigEvent::GamepadAssignments(input.gamepad_assignments),
+                            ConfigEvent::GenieCodeClear,
+                            ConfigEvent::HideOverscan(renderer.hide_overscan),
+                            ConfigEvent::MapperRevisions(deck.mapper_revisions),
+                            ConfigEvent::RamState(deck.ram_state),
+                            // Clearing recent roms is handled in a separate button
+                            ConfigEvent::Region(deck.region),
+                            ConfigEvent::RewindEnabled(emulation.rewind),
+                            ConfigEvent::RewindInterval(emulation.rewind_interval),
+                            ConfigEvent::RewindSeconds(emulation.rewind_seconds),
+                            ConfigEvent::RunAhead(emulation.run_ahead),
+                            ConfigEvent::SaveSlot(emulation.save_slot),
+                            ConfigEvent::Shader(renderer.shader),
+                            ConfigEvent::ShowMenubar(renderer.show_menubar),
+                            ConfigEvent::ShowMessages(renderer.show_messages),
+                            ConfigEvent::Speed(emulation.speed),
+                            ConfigEvent::VideoFilter(deck.filter),
+                            ConfigEvent::ZapperConnected(deck.zapper),
+                        ];
+                        for event in events {
+                            self.tx.event(event);
+                        }
+                    }
+                    if platform::supports(platform::Feature::Storage) {
+                        let data_dir = Config::default_data_dir();
+                        if ui.button("Clear Save States").clicked() {
+                            match fs::clear_dir(data_dir) {
+                                Ok(_) => self.tx.event(UiEvent::Message((
+                                    MessageType::Info,
+                                    "Save States cleared.".to_string(),
+                                ))),
+                                Err(_) => self.tx.event(UiEvent::Message((
+                                    MessageType::Error,
+                                    "Failed to clear Save States.".to_string(),
+                                ))),
+                            }
+                        }
+                    }
+                    if platform::supports(platform::Feature::Filesystem)
+                        && ui.button("Clear Recent ROMs").clicked()
+                    {
+                        self.tx.event(ConfigEvent::RecentRomsClear);
+                    }
+                });
+            });
+        });
+    }
+
+    fn emulation_tab(&mut self, ui: &mut Ui, cfg: &Config) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let EmulationConfig {
+            mut auto_save,
+            auto_save_interval,
+            mut auto_load,
+            rewind,
+            mut rewind_interval,
+            mut rewind_seconds,
+            run_ahead,
+            save_slot,
+            speed,
+            ..
+        } = cfg.emulation;
+        let DeckConfig {
+            cycle_accurate,
+            mut emulate_ppu_warmup,
+            four_player,
+            ram_state,
+            region,
+            ..
+        } = cfg.deck;
+
+        let grid = Grid::new("emulation_checkboxes")
+            .num_columns(2)
+            .spacing([80.0, 6.0]);
+        grid.show(ui, |ui| {
+            let tx = &self.tx;
+
+            Preferences::cycle_accurate_checkbox(tx, ui, cycle_accurate, "");
+            let res = ui.checkbox(&mut auto_load, "Auto-Load")
+                .on_hover_text("Automatically load game state from the current save slot on load.");
+            if res.changed() {
+                tx.event(ConfigEvent::AutoLoad(
+                    auto_load,
+                ));
+            }
+            ui.end_row();
+
+            ui.vertical(|ui| {
+                Preferences::rewind_checkbox(tx, ui, rewind, "");
+
+                ui.add_enabled_ui(rewind, |ui| {
+                    ui.indent("rewind_settings", |ui| {
+                        ui.label("Seconds:")
+                            .on_hover_text("The maximum number of seconds to rewind.");
+                        let drag = DragValue::new(&mut rewind_seconds)
+                            .clamp_range(1..=360)
+                            .suffix(" seconds");
+                        let res = ui.add(drag);
+                        if res.changed() {
+                            tx.event(ConfigEvent::RewindSeconds(rewind_seconds));
+                        }
+
+                        ui.label("Interval:")
+                            .on_hover_text("The frame interval to save rewind states.");
+                        let drag = DragValue::new(&mut rewind_interval)
+                            .clamp_range(1..=60)
+                            .suffix(" frames");
+                        let res = ui.add(drag);
+                        if res.changed() {
+                            tx.event(ConfigEvent::RewindInterval(rewind_interval));
+                        }
+                    });
+                });
+            });
+
+            ui.vertical(|ui| {
+                let res = ui.checkbox(&mut auto_save, "Auto-Save")
+                    .on_hover_text(concat!(
+                        "Automatically save game state to the current save slot ",
+                        "on exit or unloading and an optional interval. ",
+                        "Setting to 0 will disable saving on an interval.",
+                    ));
+                if res.changed() {
+                    tx.event(ConfigEvent::AutoSave(
+                        auto_save,
+                    ));
+                }
+
+                ui.add_enabled_ui(auto_save, |ui| {
+                    ui.indent("auto_save_settings", |ui| {
+                        let mut auto_save_interval = auto_save_interval.as_secs();
+                        ui.label("Interval:")
+                            .on_hover_text(concat!(
+                                "Set the interval to auto-save game state. ",
+                                "A value of `0` will still save on exit or unload while Auto-Save is enabled."
+                            ));
+                        let drag = DragValue::new(&mut auto_save_interval)
+                            .clamp_range(0..=60)
+                            .suffix(" seconds");
+                        let res = ui.add(drag);
+                        if res.changed() {
+                            tx.event(ConfigEvent::AutoSaveInterval(Duration::from_secs(auto_save_interval)));
+                        }
+                    });
+                });
+            });
+            ui.end_row();
+
+            let res = ui.checkbox(&mut emulate_ppu_warmup, "Emulate PPU Warmup")
+                .on_hover_text(concat!(
+                    "Set whether to emulate PPU warmup where writes to certain registers are ignored. ",
+                    "Can result in some games not working correctly"
+                ));
+            if res.clicked() {
+                tx.event(EmulationEvent::EmulatePpuWarmup(emulate_ppu_warmup));
+            }
+            ui.end_row();
+        });
+
+        ui.separator();
+
+        let grid = Grid::new("emulation_preferences")
+            .num_columns(4)
+            .spacing([40.0, 6.0]);
+        grid.show(ui, |ui| {
+            let tx = &self.tx;
+
+            ui.strong("Emulation Speed:");
+            Preferences::speed_slider(tx, ui, speed);
+
+            ui.strong("Run Ahead:")
+                .on_hover_cursor(CursorIcon::Help)
+                .on_hover_text("Simulate a number of frames in the future to reduce input lag.");
+            Preferences::run_ahead_slider(tx, ui, run_ahead);
+            ui.end_row();
+
+            ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                ui.strong("Save Slot:")
+                    .on_hover_cursor(CursorIcon::Help)
+                    .on_hover_text("Select which slot to use when saving or loading game state.");
+            });
+            Grid::new("save_slots")
+                .num_columns(2)
+                .spacing([20.0, 6.0])
+                .show(ui, |ui| {
+                    Preferences::save_slot_radio(tx, ui, save_slot, cfg)
+                });
+
+            ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                ui.strong("Four Player:")
+                    .on_hover_cursor(CursorIcon::Help)
+                    .on_hover_text(
+                    "Some game titles support up to 4 players (requires connected controllers).",
+                );
+            });
+            ui.vertical(|ui| Preferences::four_player_radio(tx, ui, four_player));
+            ui.end_row();
+
+            ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                ui.strong("NES Region:")
+                    .on_hover_cursor(CursorIcon::Help)
+                    .on_hover_text("Which regional NES hardware to emulate.");
+            });
+            ui.vertical(|ui| Preferences::nes_region_radio(tx, ui, region));
+
+            ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                ui.strong("RAM State:")
+                    .on_hover_cursor(CursorIcon::Help)
+                    .on_hover_text("What values are read from NES RAM on load.");
+            });
+            ui.vertical(|ui| Preferences::ram_state_radio(tx, ui, ram_state));
+            ui.end_row();
+        });
+
+        let grid = Grid::new("genie_codes").num_columns(2).spacing([40.0, 6.0]);
+        grid.show(ui, |ui| {
+            self.genie_codes_entry(ui, cfg);
+            Preferences::genie_codes_list(&self.tx, ui, cfg, false);
+        });
+    }
+
+    fn audio_tab(tx: &NesEventProxy, ui: &mut Ui, cfg: &Config) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let AudioConfig {
+            latency,
+            mut buffer_size,
+            mut enabled,
+        } = cfg.audio;
+        let DeckConfig {
+            channels_enabled, ..
+        } = cfg.deck;
+
+        let res = ui.checkbox(&mut enabled, "Enable Audio");
+        if res.clicked() {
+            tx.event(ConfigEvent::AudioEnabled(enabled));
+        }
+
+        ui.add_enabled_ui(cfg.audio.enabled, |ui| {
+            ui.indent("apu_channels", |ui| {
+                Grid::new("apu_channels")
+                    .spacing([60.0, 6.0])
+                    .num_columns(2)
+                    .show(ui, |ui| {
+
+                        let mut pulse1_enabled = channels_enabled[0];
+                        if ui.checkbox(&mut pulse1_enabled, "Enable Pulse1").clicked() {
+                            tx.event(ConfigEvent::ApuChannelEnabled((Channel::Pulse1, pulse1_enabled)));
+                        }
+                        let mut noise_enabled = channels_enabled[3];
+                        if ui.checkbox(&mut noise_enabled, "Enable Noise").clicked() {
+                            tx.event(ConfigEvent::ApuChannelEnabled((Channel::Noise, noise_enabled)));
+                        }
+                        ui.end_row();
+
+                        let mut pulse1_enabled = channels_enabled[1];
+                        if ui.checkbox(&mut pulse1_enabled, "Enable Pulse2").clicked() {
+                            tx.event(ConfigEvent::ApuChannelEnabled((Channel::Pulse2, pulse1_enabled)));
+                        }
+                        let mut dmc_enabled = channels_enabled[4];
+                        if ui.checkbox(&mut dmc_enabled, "Enable DMC").clicked() {
+                            tx.event(ConfigEvent::ApuChannelEnabled((Channel::Dmc, dmc_enabled)));
+                        }
+                        ui.end_row();
+
+                        let mut triangle_enabled = channels_enabled[2];
+                        if ui.checkbox(&mut triangle_enabled, "Enable Triangle").clicked() {
+                            tx.event(ConfigEvent::ApuChannelEnabled((Channel::Triangle, triangle_enabled)));
+                        }
+                        let mut mapper_enabled = channels_enabled[5];
+                        if ui.checkbox(&mut mapper_enabled, "Enable Mapper").clicked() {
+                            tx.event(ConfigEvent::ApuChannelEnabled((Channel::Mapper, mapper_enabled)));
+                        }
+                        ui.end_row();
+                    });
+
+                ui.separator();
+
+                Grid::new("audio_settings")
+                    .spacing([40.0, 6.0])
+                    .num_columns(2)
+                    .show(ui, |ui| {
+                        ui.strong("Buffer Size:")
+                            .on_hover_cursor(CursorIcon::Help)
+                            .on_hover_text(
+                                "The audio sample buffer size allocated to the sound driver. Increased audio buffer size can help reduce audio underruns.",
+                            );
+                        let drag = DragValue::new(&mut buffer_size)
+                            .speed(10)
+                            .clamp_range(0..=8192)
+                            .suffix(" samples");
+                        let res = ui.add(drag);
+                        if res.changed() {
+                            tx.event(ConfigEvent::AudioBuffer(buffer_size));
+                        }
+                        ui.end_row();
+
+                        ui.strong("Latency:")
+                            .on_hover_cursor(CursorIcon::Help)
+                            .on_hover_text(
+                                "The amount of queued audio before sending to the sound driver. Increased audio latency can help reduce audio underruns.",
+                            );
+                        let mut latency = latency.as_millis() as u64;
+                        let drag = DragValue::new(&mut latency)
+                            .clamp_range(0..=1000)
+                            .suffix(" ms");
+                        let res = ui.add(drag);
+                        if res.changed() {
+                            tx.event(ConfigEvent::AudioLatency(Duration::from_millis(latency)));
+                        }
+                        ui.end_row();
+                    });
+            });
+        });
+    }
+
+    fn video_tab(tx: &NesEventProxy, ui: &mut Ui, cfg: &Config) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let RendererConfig {
+            always_on_top,
+            fullscreen,
+            hide_overscan,
+            scale,
+            shader,
+            show_menubar,
+            show_messages,
+            ..
+        } = cfg.renderer;
+        let DeckConfig { filter, .. } = cfg.deck;
+
+        Grid::new("video_checkboxes")
+            .spacing([80.0, 6.0])
+            .num_columns(2)
+            .show(ui, |ui| {
+                Preferences::menubar_checkbox(tx, ui, show_menubar, "");
+                Preferences::fullscreen_checkbox(tx, ui, fullscreen, "");
+                ui.end_row();
+
+                Preferences::messages_checkbox(tx, ui, show_messages, "");
+                Preferences::embed_viewports_checkbox(tx, ui, cfg, "");
+                ui.end_row();
+
+                Preferences::overscan_checkbox(tx, ui, hide_overscan, "");
+                Preferences::always_on_top_checkbox(tx, ui, always_on_top, "");
+                ui.end_row();
+            });
+
+        ui.separator();
+
+        Grid::new("video_preferences")
+            .num_columns(2)
+            .spacing([40.0, 6.0])
+            .show(ui, |ui| {
+                ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                    ui.strong("Window Scale:");
+                });
+                Grid::new("save_slots")
+                    .num_columns(2)
+                    .spacing([20.0, 6.0])
+                    .show(ui, |ui| {
+                        Preferences::window_scale_radio(tx, ui, scale);
+                    });
+                ui.end_row();
+
+                ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                    ui.strong("Video Filter:");
+                });
+                ui.vertical(|ui| Preferences::video_filter_radio(tx, ui, filter));
+                ui.end_row();
+
+                ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                    ui.strong("Shader:");
+                });
+                ui.vertical(|ui| Preferences::shader_radio(tx, ui, shader));
+            });
+    }
+
+    fn input_tab(tx: &NesEventProxy, ui: &mut Ui, cfg: &Config) {
+        #[cfg(feature = "profiling")]
+        puffin::profile_function!();
+
+        let DeckConfig {
+            mut concurrent_dpad,
+            zapper,
+            ..
+        } = cfg.deck;
+
+        Grid::new("input_checkboxes")
+            .num_columns(2)
+            .spacing([80.0, 6.0])
+            .show(ui, |ui| {
+                Preferences::zapper_checkbox(tx, ui, zapper, "");
+                ui.end_row();
+
+                let res = ui.checkbox(&mut concurrent_dpad, "Enable Concurrent D-Pad");
+                if res.clicked() {
+                    tx.event(ConfigEvent::ConcurrentDpad(concurrent_dpad));
+                }
+            });
+    }
+
+    pub fn genie_codes_entry(&mut self, ui: &mut Ui, cfg: &Config) {
+        let tx = &self.tx;
+        ui.vertical(|ui| {
+            ui.allocate_space(Vec2::new(Gui::MENU_WIDTH, 0.0));
+
+            ui.strong("Add Genie Code(s):")
+                .on_hover_cursor(CursorIcon::Help)
+                .on_hover_text(
+                    "A Game Genie Code is a 6 or 8 letter string that temporarily modifies game memory during operation. e.g. `AATOZE` will start Super Mario Bros. with 9 lives.\n\nYou can enter one code per line."
+                );
+
+            let text_edit = TextEdit::multiline(&mut self.genie_entry.code)
+                .hint_text("e.g. AATOZE")
+                .desired_width(200.0);
+            let entry_res = ui.add(text_edit);
+            if entry_res.changed() {
+                self.genie_entry.error = None;
+            }
+
+            let has_entry = !self.genie_entry.code.is_empty();
+            let add_clicked = ui.horizontal(|ui| {
+                ui.add_enabled_ui(has_entry, |ui| {
+                    let add_clicked = ui.button("Add").clicked();
+                    if ui.button("Clear").clicked() {
+                        self.genie_entry.code.clear();
+                        self.genie_entry.error = None;
+                    }
+                    add_clicked
+                }).inner
+            }).inner;
+
+            if (has_entry && entry_res.lost_focus() && ui.input(|i| i.key_pressed(Key::Enter)))
+                || add_clicked
+            {
+                for code in self.genie_entry.code.lines() {
+                    let code = code.trim();
+                    if code.is_empty() {
+                        continue;
+                    }
+                    match GenieCode::parse(code) {
+                        Ok(hex) => {
+                            let code = GenieCode::from_raw(code.to_string(), hex);
+                            if !cfg.deck.genie_codes.contains(&code) {
+                                tx.event(ConfigEvent::GenieCodeAdded(code));
+                            }
+                        }
+                        Err(err) => self.genie_entry.error = Some(err.to_string()),
+                    }
+                }
+                if self.genie_entry.error.is_none() {
+                    self.genie_entry.code.clear();
+                }
+            }
+
+            if let Some(error) = &self.genie_entry.error {
+                ui.colored_label(ui.visuals().error_fg_color, error);
+            }
+        });
+    }
+}

--- a/tetanes/src/nes/renderer/gui/preferences.rs
+++ b/tetanes/src/nes/renderer/gui/preferences.rs
@@ -4,7 +4,7 @@ use crate::{
         event::{ConfigEvent, EmulationEvent, NesEventProxy, UiEvent},
         renderer::{
             gui::{
-                lib::{RadioValue, ShortcutText, ViewportOptions},
+                lib::{RadioValue, ShortcutText, ShowShortcut, ViewportOptions},
                 Gui, MessageType,
             },
             shader::Shader,
@@ -180,11 +180,20 @@ impl Preferences {
         }
     }
 
-    pub fn save_slot_radio(tx: &NesEventProxy, ui: &mut Ui, mut save_slot: u8, cfg: &Config) {
+    pub fn save_slot_radio(
+        tx: &NesEventProxy,
+        ui: &mut Ui,
+        mut save_slot: u8,
+        cfg: &Config,
+        show_shortcut: ShowShortcut,
+    ) {
         ui.vertical(|ui| {
             for slot in 1..=4 {
-                let radio = RadioValue::new(&mut save_slot, slot, slot.to_string())
-                    .shortcut_text(cfg.shortcut(DeckAction::SetSaveSlot(slot)));
+                let radio = RadioValue::new(&mut save_slot, slot, slot.to_string()).shortcut_text(
+                    show_shortcut
+                        .then(|| cfg.shortcut(DeckAction::SetSaveSlot(slot)))
+                        .unwrap_or_default(),
+                );
                 if ui.add(radio).changed() {
                     tx.event(ConfigEvent::SaveSlot(save_slot));
                 }
@@ -192,8 +201,11 @@ impl Preferences {
         });
         ui.vertical(|ui| {
             for slot in 5..=8 {
-                let radio = RadioValue::new(&mut save_slot, slot, slot.to_string())
-                    .shortcut_text(cfg.shortcut(DeckAction::SetSaveSlot(slot)));
+                let radio = RadioValue::new(&mut save_slot, slot, slot.to_string()).shortcut_text(
+                    show_shortcut
+                        .then(|| cfg.shortcut(DeckAction::SetSaveSlot(slot)))
+                        .unwrap_or_default(),
+                );
                 if ui.add(radio).changed() {
                     tx.event(ConfigEvent::SaveSlot(save_slot));
                 }
@@ -713,7 +725,7 @@ impl State {
                 .num_columns(2)
                 .spacing([20.0, 6.0])
                 .show(ui, |ui| {
-                    Preferences::save_slot_radio(tx, ui, save_slot, cfg)
+                    Preferences::save_slot_radio(tx, ui, save_slot, cfg, ShowShortcut::No)
                 });
 
             ui.with_layout(Layout::left_to_right(Align::Min), |ui| {

--- a/tetanes/src/sys/platform/os.rs
+++ b/tetanes/src/sys/platform/os.rs
@@ -42,7 +42,7 @@ impl Initialize for Running {
                 if let Some(parent) = path.parent() {
                     self.cfg.renderer.roms_path = Some(parent.to_path_buf());
                 }
-                self.nes_event(EmulationEvent::LoadRomPath(path));
+                self.event(EmulationEvent::LoadRomPath(path));
             } else if path.exists() {
                 self.cfg.renderer.roms_path = Some(path);
             }


### PR DESCRIPTION
This removes all uses of immediate viewports and support for them, which removes the one use of unsafe. Since tetanes is not intended to be a general-purpose library, immediate viewports are not required and, as they are less performant, not desired.

Smaller windows will be in-frame, and larger, more complex windows, will be deferred with their own repaints.

Closes #296