### PR TITLE
chore: release v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "tetanes"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "accesskit 0.17.0",
  "accesskit_winit",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "tetanes-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "tetanes-utils"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 members = ["tetanes", "tetanes-core", "tetanes-utils"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 rust-version = "1.78.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/tetanes-core/CHANGELOG.md
+++ b/tetanes-core/CHANGELOG.md
@@ -7,6 +7,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1](https://github.com/lukexor/tetanes/compare/0.11.0..0.11.1) - 2024-11-20
+
+### ⛰️  Features
+
+
+- Jalecoss88006 - ([406777a](https://github.com/lukexor/tetanes/commit/406777abad8d61490aae2a33e2e71fc617db3f55))
+- Namco163 - ([89d7fb4](https://github.com/lukexor/tetanes/commit/89d7fb4617bf844ad2090cd92f0e92cda9cc91fc))
+- Added sunsoft/fme-7 - ([303dad8](https://github.com/lukexor/tetanes/commit/303dad85d0a6586a88b7067f2070c5ac9e4da6e4))
+- Added nina003/nina006 - ([29503c3](https://github.com/lukexor/tetanes/commit/29503c3efc81fb3110eef63e9666de1e0c912015))
+- Added dxrom ([#340](https://github.com/lukexor/tetanes/pull/340)) - ([906af59](https://github.com/lukexor/tetanes/commit/906af59038e95874dda254e02998030c913d8c61))
+- Ppu-viewer ([#339](https://github.com/lukexor/tetanes/pull/339)) - ([fce7d89](https://github.com/lukexor/tetanes/commit/fce7d89f78148e9a367d47122eef7e6e8fe45b34))
+- Bandai mappers 016, 153, 157, 159 ([#335](https://github.com/lukexor/tetanes/pull/335)) - ([f555ea4](https://github.com/lukexor/tetanes/commit/f555ea48d0273bc9d41b998926d451398acbb73c))
+- Allow exporting save states in web ([#311](https://github.com/lukexor/tetanes/pull/311)) - ([627bbec](https://github.com/lukexor/tetanes/commit/627bbece49739ff479e69ba9e83df828c4d4a633))
+
+### 🐛 Bug Fixes
+
+
+- Fix tetanes-core compiling on stable. closes [#360](https://github.com/lukexor/tetanes/pull/360) - ([adc5673](https://github.com/lukexor/tetanes/commit/adc5673a3ed5d80aff339c3ab6d95013fcb2d715))
+- Fixed bank size check - ([c84c012](https://github.com/lukexor/tetanes/commit/c84c012c310ad466c5167b94f0228f5a482dec43))
+- Fixed video frame size - ([153094d](https://github.com/lukexor/tetanes/commit/153094d81d444376b112224409544375588c4f97))
+- Ensure pixel brightness is using the same palette - ([ad2f873](https://github.com/lukexor/tetanes/commit/ad2f873f5652016b96317c000b4abbe0e35de421))
+
+### 🎨 Styling
+
+
+- Slight cleanup - ([63e31a9](https://github.com/lukexor/tetanes/commit/63e31a9755266bec88d5c79e064506999f03aea2))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- More dependency cleanup - ([1971e4f](https://github.com/lukexor/tetanes/commit/1971e4f2c5aaf6f8a2d6ce2a03c978362d44afe1))
+
+
 ## [0.11.0](https://github.com/lukexor/tetanes/compare/0.10.0..0.11.0) - 2024-06-12
 
 ### ⛰️  Features

--- a/tetanes/CHANGELOG.md
+++ b/tetanes/CHANGELOG.md
@@ -7,6 +7,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1](https://github.com/lukexor/tetanes/compare/0.11.0..0.11.1) - 2024-11-20
+
+### ⛰️  Features
+
+
+- Namco163 - ([89d7fb4](https://github.com/lukexor/tetanes/commit/89d7fb4617bf844ad2090cd92f0e92cda9cc91fc))
+- Ppu-viewer ([#339](https://github.com/lukexor/tetanes/pull/339)) - ([fce7d89](https://github.com/lukexor/tetanes/commit/fce7d89f78148e9a367d47122eef7e6e8fe45b34))
+- Allow exporting save states in web ([#311](https://github.com/lukexor/tetanes/pull/311)) - ([627bbec](https://github.com/lukexor/tetanes/commit/627bbece49739ff479e69ba9e83df828c4d4a633))
+- Add a debug build label - ([46b3d94](https://github.com/lukexor/tetanes/commit/46b3d94e5fd24900a95554a295257f0891ac1c53))
+- Add test panic debug button - ([3866efa](https://github.com/lukexor/tetanes/commit/3866efab39ced8f3431ee27d24962a55397a9f07))
+- Added screen reader/accesskit support - ([5fd1a73](https://github.com/lukexor/tetanes/commit/5fd1a73f112f74a6c0a81e722485842dd37e0a38))
+- Added ui setting/debug windows - ([db8b122](https://github.com/lukexor/tetanes/commit/db8b122af6c5a52ad23ed89ffd6f2feb35515603))
+
+### 🐛 Bug Fixes
+
+
+- Fixed wasm - ([bd27814](https://github.com/lukexor/tetanes/commit/bd278140bcc7e7d433917f14e99038f2e6453027))
+- Fix scroll issues - ([218d786](https://github.com/lukexor/tetanes/commit/218d7860421eb4cfc4d7b833132f4c476935777a))
+- Fixed increasing scale on web - ([8c4265e](https://github.com/lukexor/tetanes/commit/8c4265e10fc8b62cd7dcaa8a828fed1a07100a9f))
+- Fixed shortcut text - ([cb73c21](https://github.com/lukexor/tetanes/commit/cb73c216936ad49dca4e2595485df4ccea957eaa))
+- Fixed joypad keybinds and some UI styling - ([bc2f093](https://github.com/lukexor/tetanes/commit/bc2f093b4d02c54744f791f336a102424a7e5af1))
+- Enable puffin on wasm - ([0b6f794](https://github.com/lukexor/tetanes/commit/0b6f79429c5d2a642c0ef6301bbcc9818973a234))
+- Fix window theme - ([e3c42c7](https://github.com/lukexor/tetanes/commit/e3c42c7720f558c7348e2b82b3573d4748158850))
+- Fixed window aspect ratio - ([17db5c8](https://github.com/lukexor/tetanes/commit/17db5c8a037ab3aefab560bca67545964069658f))
+- Don't log/error when sending frames while paused - ([50825f8](https://github.com/lukexor/tetanes/commit/50825f82e9f04418fdefd56707ef2ec50cddd5ed))
+- Fixed pause state when loading replay - ([d743b31](https://github.com/lukexor/tetanes/commit/d743b31c190cd93e42e3ab78b497e59bcc4ade88))
+- Fixed roms path to default to current directory, if valid, and canonicalize - ([e00273f](https://github.com/lukexor/tetanes/commit/e00273f740f7fc095bc02c7ce6d0ba132a14c9bc))
+- Move some calculations to vertex shader that don't depend on v_uv - ([a6f262d](https://github.com/lukexor/tetanes/commit/a6f262db5d83950e86e0ec78bb74fc63e5c2bf85))
+- Fixed logging location - ([ff36033](https://github.com/lukexor/tetanes/commit/ff36033d7bbbf64924d97d6e9a88dcf4db7dc60c))
+- Fixed issue with lower end platforms not supporting larger texture dimensions - ([ef214db](https://github.com/lukexor/tetanes/commit/ef214dbc2f2eee016b7abdb0c2b0ee1858381ee4))
+- Fix window resizing while handling zoom changes - ([6b3f690](https://github.com/lukexor/tetanes/commit/6b3f690b8ec21b907d353a7cad8561217e8d9dcf))
+
+### 🚜 Refactor
+
+
+- Removed egui-wgpu and egui-winit dependencies. ([#315](https://github.com/lukexor/tetanes/pull/315)) - ([b3d4e2c](https://github.com/lukexor/tetanes/commit/b3d4e2c70c6ee4cfa9aaf53a11c1ae802610ff99))
+- Platform/ui cleanup - ([39f66e6](https://github.com/lukexor/tetanes/commit/39f66e6e912f9c95cf9c458cd072e5e041af09e3))
+- Moved around platform code to condense it - ([0f18928](https://github.com/lukexor/tetanes/commit/0f18928b8f8ed031cac7a170557c0296916c99bc))
+- Prefer deferred viewports ([#306](https://github.com/lukexor/tetanes/pull/306)) - ([e1e60d1](https://github.com/lukexor/tetanes/commit/e1e60d19599ab883cbb034047519e6eb831d6c6c))
+
+### 🎨 Styling
+
+
+- Fixed format - ([d62ea28](https://github.com/lukexor/tetanes/commit/d62ea285cb5fe73ac41e7364f0ca3f32281a0e88))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Updated deps - ([4712d6d](https://github.com/lukexor/tetanes/commit/4712d6d6de3ce7eccec8f1971fcb0f2411f91e3d))
+- More dependency cleanup - ([1971e4f](https://github.com/lukexor/tetanes/commit/1971e4f2c5aaf6f8a2d6ce2a03c978362d44afe1))
+- Clean up dependencies - ([254fe54](https://github.com/lukexor/tetanes/commit/254fe543293b0c96c78ce25bdaeef2f250a9fb14))
+
+
 ## [0.11.0](https://github.com/lukexor/tetanes/compare/0.10.0..0.11.0) - 2024-06-12
 
 ### ⛰️  Features

--- a/tetanes/src/nes/audio.rs
+++ b/tetanes/src/nes/audio.rs
@@ -95,7 +95,7 @@ impl Audio {
                 .output
                 .as_ref()
                 .and_then(|output| output.mixer.as_ref())
-                .map_or(false, |mixer| !mixer.paused)
+                .is_some_and(|mixer| !mixer.paused)
     }
 
     /// Set whether the audio mixer is enabled. Returns [`State`] representing the state of
@@ -186,7 +186,7 @@ impl Audio {
         self.output
             .as_ref()
             .and_then(|output| output.mixer.as_ref())
-            .map_or(false, |mixer| mixer.recording.is_some())
+            .is_some_and(|mixer| mixer.recording.is_some())
     }
 
     /// Start recording audio to a file.

--- a/tetanes/src/nes/emulation.rs
+++ b/tetanes/src/nes/emulation.rs
@@ -209,7 +209,7 @@ impl Emulation {
         cfg: &Config,
     ) -> anyhow::Result<Self> {
         let threaded = cfg.emulation.threaded
-            && std::thread::available_parallelism().map_or(false, |count| count.get() > 1);
+            && std::thread::available_parallelism().is_ok_and(|count| count.get() > 1);
         let backend = if threaded {
             Threads::Multi(Multi::spawn(tx, frame_tx, cfg)?)
         } else {
@@ -323,7 +323,7 @@ impl State {
             frame_time_diag: FrameTimeDiag::new(),
             run_state: RunState::Paused,
             threaded: cfg.emulation.threaded
-                && std::thread::available_parallelism().map_or(false, |count| count.get() > 1),
+                && std::thread::available_parallelism().is_ok_and(|count| count.get() > 1),
             rewinding: false,
             rewind,
             record: Record::new(),

--- a/tetanes/src/nes/renderer/gui.rs
+++ b/tetanes/src/nes/renderer/gui.rs
@@ -1257,7 +1257,7 @@ impl Gui {
                             if self
                                 .cfg
                                 .action_input(DeckAction::ZapperAimOffscreen)
-                                .map_or(false, |input| input_down(ui, gamepads, &self.cfg, input))
+                                .is_some_and(|input| input_down(ui, gamepads, &self.cfg, input))
                             {
                                 let pos = (Ppu::WIDTH + 10, Ppu::HEIGHT + 10);
                                 tx.event(EmulationEvent::ZapperAim(pos));

--- a/tetanes/src/nes/renderer/gui/keybinds.rs
+++ b/tetanes/src/nes/renderer/gui/keybinds.rs
@@ -84,7 +84,7 @@ impl Keybinds {
     }
 
     pub fn wants_input(&self) -> bool {
-        self.state.try_lock().map_or(false, |state| {
+        self.state.try_lock().is_some_and(|state| {
             state.pending_input.is_some() || state.gamepad_unassign_confirm.is_some()
         })
     }

--- a/tetanes/src/nes/renderer/gui/lib.rs
+++ b/tetanes/src/nes/renderer/gui/lib.rs
@@ -59,7 +59,7 @@ pub fn cursor_to_zapper(x: f32, y: f32, rect: Rect) -> Option<Pos2> {
 
 pub fn input_down(ui: &mut Ui, gamepads: Option<&Gamepads>, cfg: &Config, input: Input) -> bool {
     ui.input_mut(|i| match input {
-        Input::Key(keycode, modifier_state) => key_from_keycode(keycode).map_or(false, |key| {
+        Input::Key(keycode, modifier_state) => key_from_keycode(keycode).is_some_and(|key| {
             let modifiers = modifiers_from_modifiers_state(modifier_state);
             i.key_down(key) && i.modifiers == modifiers
         }),
@@ -68,16 +68,16 @@ pub fn input_down(ui: &mut Ui, gamepads: Option<&Gamepads>, cfg: &Config, input:
             .gamepad_assigned_to(player)
             .and_then(|uuid| gamepads.map(|g| g.gamepad_by_uuid(&uuid)))
             .flatten()
-            .map_or(false, |g| g.is_pressed(button)),
+            .is_some_and(|g| g.is_pressed(button)),
         Input::Mouse(mouse_button) => pointer_button_from_mouse(mouse_button)
-            .map_or(false, |pointer| i.pointer.button_down(pointer)),
+            .is_some_and(|pointer| i.pointer.button_down(pointer)),
         Input::Axis(player, axis, direction) => cfg
             .input
             .gamepad_assigned_to(player)
             .and_then(|uuid| gamepads.map(|g| g.gamepad_by_uuid(&uuid)))
             .flatten()
             .and_then(|g| g.axis_data(axis).map(|data| data.value()))
-            .map_or(false, |value| {
+            .is_some_and(|value| {
                 let (dir, state) = Gamepads::axis_state(value);
                 dir == Some(direction) && state == ElementState::Pressed
             }),


### PR DESCRIPTION
## 🤖 New release
* `tetanes`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `tetanes-core`: 0.11.0 -> 0.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `tetanes`
<blockquote>

## [0.11.1](https://github.com/lukexor/tetanes/compare/0.11.0..0.11.1) - 2024-11-20

### ⛰️  Features


- Namco163 - ([89d7fb4](https://github.com/lukexor/tetanes/commit/89d7fb4617bf844ad2090cd92f0e92cda9cc91fc))
- Ppu-viewer ([#339](https://github.com/lukexor/tetanes/pull/339)) - ([fce7d89](https://github.com/lukexor/tetanes/commit/fce7d89f78148e9a367d47122eef7e6e8fe45b34))
- Allow exporting save states in web ([#311](https://github.com/lukexor/tetanes/pull/311)) - ([627bbec](https://github.com/lukexor/tetanes/commit/627bbece49739ff479e69ba9e83df828c4d4a633))
- Add a debug build label - ([46b3d94](https://github.com/lukexor/tetanes/commit/46b3d94e5fd24900a95554a295257f0891ac1c53))
- Add test panic debug button - ([3866efa](https://github.com/lukexor/tetanes/commit/3866efab39ced8f3431ee27d24962a55397a9f07))
- Added screen reader/accesskit support - ([5fd1a73](https://github.com/lukexor/tetanes/commit/5fd1a73f112f74a6c0a81e722485842dd37e0a38))
- Added ui setting/debug windows - ([db8b122](https://github.com/lukexor/tetanes/commit/db8b122af6c5a52ad23ed89ffd6f2feb35515603))

### 🐛 Bug Fixes


- Fixed wasm - ([bd27814](https://github.com/lukexor/tetanes/commit/bd278140bcc7e7d433917f14e99038f2e6453027))
- Fix scroll issues - ([218d786](https://github.com/lukexor/tetanes/commit/218d7860421eb4cfc4d7b833132f4c476935777a))
- Fixed increasing scale on web - ([8c4265e](https://github.com/lukexor/tetanes/commit/8c4265e10fc8b62cd7dcaa8a828fed1a07100a9f))
- Fixed shortcut text - ([cb73c21](https://github.com/lukexor/tetanes/commit/cb73c216936ad49dca4e2595485df4ccea957eaa))
- Fixed joypad keybinds and some UI styling - ([bc2f093](https://github.com/lukexor/tetanes/commit/bc2f093b4d02c54744f791f336a102424a7e5af1))
- Enable puffin on wasm - ([0b6f794](https://github.com/lukexor/tetanes/commit/0b6f79429c5d2a642c0ef6301bbcc9818973a234))
- Fix window theme - ([e3c42c7](https://github.com/lukexor/tetanes/commit/e3c42c7720f558c7348e2b82b3573d4748158850))
- Fixed window aspect ratio - ([17db5c8](https://github.com/lukexor/tetanes/commit/17db5c8a037ab3aefab560bca67545964069658f))
- Don't log/error when sending frames while paused - ([50825f8](https://github.com/lukexor/tetanes/commit/50825f82e9f04418fdefd56707ef2ec50cddd5ed))
- Fixed pause state when loading replay - ([d743b31](https://github.com/lukexor/tetanes/commit/d743b31c190cd93e42e3ab78b497e59bcc4ade88))
- Fixed roms path to default to current directory, if valid, and canonicalize - ([e00273f](https://github.com/lukexor/tetanes/commit/e00273f740f7fc095bc02c7ce6d0ba132a14c9bc))
- Move some calculations to vertex shader that don't depend on v_uv - ([a6f262d](https://github.com/lukexor/tetanes/commit/a6f262db5d83950e86e0ec78bb74fc63e5c2bf85))
- Fixed logging location - ([ff36033](https://github.com/lukexor/tetanes/commit/ff36033d7bbbf64924d97d6e9a88dcf4db7dc60c))
- Fixed issue with lower end platforms not supporting larger texture dimensions - ([ef214db](https://github.com/lukexor/tetanes/commit/ef214dbc2f2eee016b7abdb0c2b0ee1858381ee4))
- Fix window resizing while handling zoom changes - ([6b3f690](https://github.com/lukexor/tetanes/commit/6b3f690b8ec21b907d353a7cad8561217e8d9dcf))

### 🚜 Refactor


- Removed egui-wgpu and egui-winit dependencies. ([#315](https://github.com/lukexor/tetanes/pull/315)) - ([b3d4e2c](https://github.com/lukexor/tetanes/commit/b3d4e2c70c6ee4cfa9aaf53a11c1ae802610ff99))
- Platform/ui cleanup - ([39f66e6](https://github.com/lukexor/tetanes/commit/39f66e6e912f9c95cf9c458cd072e5e041af09e3))
- Moved around platform code to condense it - ([0f18928](https://github.com/lukexor/tetanes/commit/0f18928b8f8ed031cac7a170557c0296916c99bc))
- Prefer deferred viewports ([#306](https://github.com/lukexor/tetanes/pull/306)) - ([e1e60d1](https://github.com/lukexor/tetanes/commit/e1e60d19599ab883cbb034047519e6eb831d6c6c))

### 🎨 Styling


- Fixed format - ([d62ea28](https://github.com/lukexor/tetanes/commit/d62ea285cb5fe73ac41e7364f0ca3f32281a0e88))

### ⚙️ Miscellaneous Tasks


- Updated deps - ([4712d6d](https://github.com/lukexor/tetanes/commit/4712d6d6de3ce7eccec8f1971fcb0f2411f91e3d))
- More dependency cleanup - ([1971e4f](https://github.com/lukexor/tetanes/commit/1971e4f2c5aaf6f8a2d6ce2a03c978362d44afe1))
- Clean up dependencies - ([254fe54](https://github.com/lukexor/tetanes/commit/254fe543293b0c96c78ce25bdaeef2f250a9fb14))
</blockquote>

## `tetanes-core`
<blockquote>

## [0.11.1](https://github.com/lukexor/tetanes/compare/0.11.0..0.11.1) - 2024-11-20

### ⛰️  Features


- Jalecoss88006 - ([406777a](https://github.com/lukexor/tetanes/commit/406777abad8d61490aae2a33e2e71fc617db3f55))
- Namco163 - ([89d7fb4](https://github.com/lukexor/tetanes/commit/89d7fb4617bf844ad2090cd92f0e92cda9cc91fc))
- Added sunsoft/fme-7 - ([303dad8](https://github.com/lukexor/tetanes/commit/303dad85d0a6586a88b7067f2070c5ac9e4da6e4))
- Added nina003/nina006 - ([29503c3](https://github.com/lukexor/tetanes/commit/29503c3efc81fb3110eef63e9666de1e0c912015))
- Added dxrom ([#340](https://github.com/lukexor/tetanes/pull/340)) - ([906af59](https://github.com/lukexor/tetanes/commit/906af59038e95874dda254e02998030c913d8c61))
- Ppu-viewer ([#339](https://github.com/lukexor/tetanes/pull/339)) - ([fce7d89](https://github.com/lukexor/tetanes/commit/fce7d89f78148e9a367d47122eef7e6e8fe45b34))
- Bandai mappers 016, 153, 157, 159 ([#335](https://github.com/lukexor/tetanes/pull/335)) - ([f555ea4](https://github.com/lukexor/tetanes/commit/f555ea48d0273bc9d41b998926d451398acbb73c))
- Allow exporting save states in web ([#311](https://github.com/lukexor/tetanes/pull/311)) - ([627bbec](https://github.com/lukexor/tetanes/commit/627bbece49739ff479e69ba9e83df828c4d4a633))

### 🐛 Bug Fixes


- Fix tetanes-core compiling on stable. closes [#360](https://github.com/lukexor/tetanes/pull/360) - ([adc5673](https://github.com/lukexor/tetanes/commit/adc5673a3ed5d80aff339c3ab6d95013fcb2d715))
- Fixed bank size check - ([c84c012](https://github.com/lukexor/tetanes/commit/c84c012c310ad466c5167b94f0228f5a482dec43))
- Fixed video frame size - ([153094d](https://github.com/lukexor/tetanes/commit/153094d81d444376b112224409544375588c4f97))
- Ensure pixel brightness is using the same palette - ([ad2f873](https://github.com/lukexor/tetanes/commit/ad2f873f5652016b96317c000b4abbe0e35de421))

### 🎨 Styling


- Slight cleanup - ([63e31a9](https://github.com/lukexor/tetanes/commit/63e31a9755266bec88d5c79e064506999f03aea2))

### ⚙️ Miscellaneous Tasks


- More dependency cleanup - ([1971e4f](https://github.com/lukexor/tetanes/commit/1971e4f2c5aaf6f8a2d6ce2a03c978362d44afe1))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).