### PR TITLE
chore: release v0.12.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,12 +103,12 @@ jobs:
       # Windows/macOS/wasm32/ubuntu x86_64 can all build/cross build normally
       - if: startsWith(matrix.os, 'macos') || startsWith(matrix.target, 'x86_64') || startsWith(matrix.target, 'wasm32')
         run: |
-          cargo make build-artifacts -- --target ${{ matrix.target }}
+          time cargo make build-artifacts -- --target ${{ matrix.target }}
       # ubuntu aarch64 requires cross building
       - if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.target, 'aarch64')
         run: |
           export CROSS_CONTAINER_IN_CONTAINER=true
-          cargo make build-artifacts -- --target ${{ matrix.target }} --cross
+          time cargo make build-artifacts -- --target ${{ matrix.target }} --cross
       - uses: actions/upload-artifact@v4
         name: "Upload artifacts"
         with:
@@ -122,7 +122,10 @@ jobs:
           echo "release_tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
   update-homebrew-formula:
     name: Update Homebrew Formula
-    if: startsWith(github.event.release.name, 'tetanes') || inputs.build
+    if: >
+      (startsWith(github.event.release.name, 'tetanes')
+        && !startsWith(github.event.release.name, 'tetanes-core'))
+      || inputs.build
     needs: build-and-upload-artifacts
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,13 @@ on:
 
 env:
   CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_TERM_COLOR: always
+  RUST_LOG: debug
   RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
+  RUSTDOCFLAGS: "-D warnings"
 
 jobs:
   format:
@@ -30,7 +35,8 @@ jobs:
           targets: wasm32-unknown-unknown
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all --check
+      - run: |
+          time cargo fmt --all --check
 
   lint-web:
     name: Lint Web
@@ -46,7 +52,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: |
-          cargo clippy --lib --bin tetanes --target wasm32-unknown-unknown --all-features --keep-going -- -D warnings
+          time cargo clippy --locked --lib --bin tetanes --target wasm32-unknown-unknown --all-features --keep-going
 
   lint-tetanes:
     name: Lint TetaNES (${{ matrix.os }})
@@ -69,7 +75,7 @@ jobs:
           sudo apt update
           sudo apt install -y libudev-dev libasound2-dev
       - run: |
-          cargo clippy -p tetanes --all-features --keep-going -- -D warnings
+          cargo clippy --locked -p tetanes --all-features --keep-going
 
   lint-tetanes-core:
     name: Lint TetaNES Core (${{ matrix.os }})
@@ -78,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        toolchain: [nightly, stable, 1.78]
+        toolchain: [nightly, stable, 1.85]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,7 +95,8 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: |
-          cargo clippy -p tetanes-core --all-features --keep-going -- -D warnings
+          # Unset nightly RUSTFLAGS so we can lint with non-nightly toolchains
+          CARGO_ENCODED_RUSTFLAGS= cargo +${{ matrix.toolchain }} clippy --locked -p tetanes-core --all-features --keep-going
 
   test-tetanes:
     name: Test TetaNES
@@ -101,12 +108,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - run: |
           sudo apt update
           sudo apt install -y libudev-dev libasound2-dev
       - run: |
-          cargo test -p tetanes --all-features --no-fail-fast
+          cargo nextest run --locked -p tetanes --all-features --no-fail-fast --no-tests warn
 
   test-tetanes-core:
     name: Test TetaNES Core
@@ -118,9 +128,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - run: |
-          cargo test -p tetanes-core --all-features --no-fail-fast
+          cargo nextest run --locked -p tetanes-core --all-features --no-fail-fast
 
   docs:
     name: Docs
@@ -132,6 +145,5 @@ jobs:
           toolchain: nightly
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - env:
-          RUSTDOCFLAGS: -D warnings
-        run: cargo doc --no-deps --document-private-items --all-features --workspace --examples --keep-going
+      - run: |
+          time cargo doc --locked --no-deps --document-private-items --all-features --workspace --examples --keep-going

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -277,7 +277,7 @@ dependencies = [
  "clipboard-win",
  "log",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "parking_lot",
  "wl-clipboard-rs",
@@ -313,23 +313,20 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c39d707614dbcc6bed00015539f488d8e3fe3e66ed60961efc0c90f4b380b3"
+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
 dependencies = [
  "async-fs",
  "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.8.5",
+ "rand",
  "raw-window-handle",
  "serde",
  "serde_repr",
  "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.32.6",
  "zbus",
 ]
 
@@ -649,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
+dependencies = [
+ "objc2 0.6.0",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -845,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -856,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1216,6 +1222,18 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2 0.6.0",
+ "libc",
+ "objc2 0.6.0",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1981,9 +1999,9 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -2002,12 +2020,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -2440,9 +2458,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -2884,7 +2902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -2894,13 +2912,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2 0.6.0",
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2912,7 +2942,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2924,9 +2954,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.0",
 ]
 
 [[package]]
@@ -2935,7 +2975,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2947,7 +2987,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -2966,7 +3006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -2980,6 +3020,7 @@ checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
  "bitflags 2.9.0",
  "objc2 0.6.0",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2988,9 +3029,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -3001,7 +3042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3013,7 +3054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -3036,7 +3077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -3056,7 +3097,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3068,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -3538,22 +3579,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3562,19 +3592,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
  "zerocopy 0.8.23",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3584,16 +3604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
+ "rand_core",
 ]
 
 [[package]]
@@ -3703,9 +3714,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3748,19 +3759,19 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a24763657bff09769a8ccf12c8b8a50416fb035fe199263b4c5071e4e3f006f"
+checksum = "80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d"
 dependencies = [
  "ashpd",
- "block2",
- "core-foundation 0.10.0",
- "core-foundation-sys",
+ "block2 0.6.0",
+ "dispatch2",
  "js-sys",
  "log",
- "objc2 0.5.2",
- "objc2-app-kit",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.0",
+ "objc2-app-kit 0.3.0",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
  "pollster",
  "raw-window-handle",
  "urlencoding",
@@ -3781,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4309,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "tetanes"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "accesskit 0.18.0",
  "accesskit_winit",
@@ -4363,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "tetanes-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4376,7 +4387,7 @@ dependencies = [
  "image",
  "pprof",
  "puffin",
- "rand 0.9.0",
+ "rand",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4388,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "tetanes-utils"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4533,9 +4544,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4568,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4808,7 +4819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
- "rand 0.9.0",
+ "rand",
  "serde",
  "uuid-rng-internal",
 ]
@@ -5481,13 +5492,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-result 0.3.1",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5602,11 +5613,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5628,6 +5655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5644,6 +5677,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5664,10 +5703,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5688,6 +5739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5704,6 +5761,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5724,6 +5787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,6 +5811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "winit"
 version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,7 +5826,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop",
  "cfg_aliases 0.2.1",
@@ -5765,7 +5840,7 @@ dependencies = [
  "memmap2",
  "ndk 0.9.0",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
@@ -5796,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 members = ["tetanes", "tetanes-core", "tetanes-utils"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Luke Petherbridge <me@lukeworks.tech>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Luke Petherbridge <me@lukeworks.tech>"]
 readme = "README.md"
-documentation = "https://docs.rs/tetanes"
+documentation = "https://docs.rs/tetanes/0.12.0"
 repository = "https://github.com/lukexor/tetanes.git"
 homepage = "https://lukeworks.tech/tetanes"
 

--- a/tetanes-core/CHANGELOG.md
+++ b/tetanes-core/CHANGELOG.md
@@ -1,3 +1,35 @@
+<!-- markdownlint-disable-file no-duplicate-heading -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.12.1](https://github.com/lukexor/tetanes/compare/0.12.0..0.12.1) - 2025-03-13
+
+### ⛰️  Features
+
+
+- Added shortcuts for shaders and ppu warmup flag - ([408b122](https://github.com/lukexor/tetanes/commit/408b122ed98f7edb7a26085fb921aa006bde7091))
+
+### 🐛 Bug Fixes
+
+
+- Fixed issues with some mmc1 games - ([496cf41](https://github.com/lukexor/tetanes/commit/496cf41ced63949fd6d8be5402989e927baf92b8))
+
+### 📚 Documentation
+
+
+- Updated changelog and readmes - ([a4a3e8c](https://github.com/lukexor/tetanes/commit/a4a3e8c0775a7261b91f4238756ac5a20d2c4b48))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Fix/update ci, docs, and fixed nightly issue with tetanes-core - ([ceaed8e](https://github.com/lukexor/tetanes/commit/ceaed8e9e0ced7f693e186ea29e77f01fecfe91c))
+
+
 <!-- markdownlint-disable-file no-duplicate-heading no-multiple-blanks line-length -->
 
 # Changelog

--- a/tetanes-core/Cargo.toml
+++ b/tetanes-core/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "tetanes-core"
 version.workspace = true
+rust-version = "1.85.0"
 edition.workspace = true
 license.workspace = true
 description = "A NES Emulator written in Rust"
 authors.workspace = true
 readme = "README.md"
-documentation.workspace = true
+documentation = "https://docs.rs/tetanes-core/0.12.0"
 repository.workspace = true
 homepage.workspace = true
 categories = ["emulators"]

--- a/tetanes-core/README.md
+++ b/tetanes-core/README.md
@@ -43,7 +43,7 @@ Some community examples:
 
 ## Minimum Supported Rust Version (MSRV)
 
-The current minimum Rust version is `1.78.0`.
+The current minimum Rust version is `1.85.0`.
 
 ## Features
 

--- a/tetanes-core/src/apu/triangle.rs
+++ b/tetanes-core/src/apu/triangle.rs
@@ -80,7 +80,7 @@ impl Triangle {
     /// $400B Triangle timer high
     pub fn write_timer_hi(&mut self, val: u8) {
         self.length.write(val >> 3);
-        self.timer.period = (self.timer.period & 0x00FF) | u64::from(val & 0x07) << 8; // D2..D0
+        self.timer.period = (self.timer.period & 0x00FF) | (u64::from(val & 0x07) << 8); // D2..D0
         self.linear.reload = true;
     }
 

--- a/tetanes-core/src/mapper/m005_exrom.rs
+++ b/tetanes-core/src/mapper/m005_exrom.rs
@@ -493,16 +493,16 @@ impl Exrom {
         };
         // CHR banks are in actual page sizes which means they need to be shifted appropriately
         match self.regs.chr_mode {
-            ChrMode::Bank8k => self.chr_banks.set_range(0, 7, hi | banks[7] << 3),
+            ChrMode::Bank8k => self.chr_banks.set_range(0, 7, hi | (banks[7] << 3)),
             ChrMode::Bank4k => {
-                self.chr_banks.set_range(0, 3, hi | banks[3] << 2);
-                self.chr_banks.set_range(4, 7, hi | banks[7] << 2);
+                self.chr_banks.set_range(0, 3, hi | (banks[3] << 2));
+                self.chr_banks.set_range(4, 7, hi | (banks[7] << 2));
             }
             ChrMode::Bank2k => {
-                self.chr_banks.set_range(0, 1, hi | banks[1] << 1);
-                self.chr_banks.set_range(2, 3, hi | banks[3] << 1);
-                self.chr_banks.set_range(4, 5, hi | banks[5] << 1);
-                self.chr_banks.set_range(6, 7, hi | banks[7] << 1);
+                self.chr_banks.set_range(0, 1, hi | (banks[1] << 1));
+                self.chr_banks.set_range(2, 3, hi | (banks[3] << 1));
+                self.chr_banks.set_range(4, 5, hi | (banks[5] << 1));
+                self.chr_banks.set_range(6, 7, hi | (banks[7] << 1));
             }
             ChrMode::Bank1k => {
                 self.chr_banks.set(0, hi | banks[0]);
@@ -754,7 +754,7 @@ impl MapRead for Exrom {
                 // I = IRQ (0 = No IRQ triggered. 1 = IRQ was triggered.) Reading $5010 acknowledges the IRQ and clears this flag.
                 // M = Mode select (0 = write mode. 1 = read mode.)
                 let irq = Cpu::has_irq(Irq::DMC);
-                MappedRead::Data(u8::from(irq) << 7 | self.dmc_mode)
+                MappedRead::Data((u8::from(irq) << 7) | self.dmc_mode)
             }
             0x5100 => MappedRead::Data(self.regs.prg_mode as u8),
             0x5101 => MappedRead::Data(self.regs.chr_mode as u8),
@@ -793,7 +793,7 @@ impl MapRead for Exrom {
                 // Reading $5204 will clear the pending flag (acknowledging the IRQ).
                 // Clearing is done in the read() function
                 MappedRead::Data(
-                    u8::from(irq_pending) << 7 | u8::from(self.irq_state.in_frame) << 6,
+                    (u8::from(irq_pending) << 7) | (u8::from(self.irq_state.in_frame) << 6),
                 )
             }
             0x5205 => MappedRead::Data((self.regs.mult_result & 0xFF) as u8),

--- a/tetanes-core/src/mapper/m069_sunsoft_fme7.rs
+++ b/tetanes-core/src/mapper/m069_sunsoft_fme7.rs
@@ -226,13 +226,13 @@ impl Audio {
     #[inline]
     pub fn period(&self, channel: usize) -> u16 {
         let register = channel * 2;
-        u16::from(self.registers[register]) | u16::from(self.registers[register + 1]) << 8
+        u16::from(self.registers[register]) | (u16::from(self.registers[register + 1]) << 8)
     }
 
     #[must_use]
     #[inline]
     pub fn envelope_period(&self) -> u16 {
-        u16::from(self.registers[0x0B]) | u16::from(self.registers[0x0C]) << 8
+        u16::from(self.registers[0x0B]) | (u16::from(self.registers[0x0C]) << 8)
     }
 
     #[must_use]

--- a/tetanes-core/src/mem.rs
+++ b/tetanes-core/src/mem.rs
@@ -330,7 +330,7 @@ pub trait Write {
     }
 }
 
-/// RAM [`Memory`] in a given state on startup.
+/// RAM in a given state on startup.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[must_use]
 pub enum RamState {
@@ -407,7 +407,7 @@ impl FromStr for RamState {
     }
 }
 
-/// Represents allowed [`Memory`] bank access.
+/// Represents allowed memory bank access.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[must_use]
 pub enum BankAccess {
@@ -416,7 +416,7 @@ pub enum BankAccess {
     ReadWrite,
 }
 
-/// Represents a set of [`Memory`] banks.
+/// Represents a set of memory banks.
 #[derive(Clone, Serialize, Deserialize)]
 #[must_use]
 pub struct Banks {
@@ -529,7 +529,7 @@ impl Banks {
     }
 
     #[must_use]
-    pub const fn banks_len(&self) -> usize {
+    pub fn banks_len(&self) -> usize {
         self.banks.len()
     }
 

--- a/tetanes-core/src/ppu.rs
+++ b/tetanes-core/src/ppu.rs
@@ -399,7 +399,7 @@ impl Ppu {
                     let tile_lo = self.bus.peek_chr(tile_addr);
                     let tile_hi = self.bus.peek_chr(tile_addr + 8);
                     for x in 0..8 {
-                        let tile_palette = ((tile_hi >> x) & 1) << 1 | (tile_lo >> x) & 1;
+                        let tile_palette = (((tile_hi >> x) & 1) << 1) | (tile_lo >> x) & 1;
                         let palette = palette_addr | u16::from(tile_palette);
                         let color = self.bus.peek_palette(
                             Ppu::PALETTE_START | ((palette & 0x03 > 0) as u16 * palette),
@@ -499,7 +499,7 @@ impl Ppu {
                         let spr_color = if flip_horizontal {
                             (((tile_hi >> x) & 0x01) << 1) | ((tile_lo >> x) & 0x01)
                         } else {
-                            (((tile_hi << x) & 0x80) >> 6) | ((tile_lo << x) & 0x80) >> 7
+                            (((tile_hi << x) & 0x80) >> 6) | (((tile_lo << x) & 0x80) >> 7)
                         };
                         let palette = palette + spr_color;
                         let color = self.bus.peek_palette(

--- a/tetanes-core/src/ppu/scroll.rs
+++ b/tetanes-core/src/ppu/scroll.rs
@@ -235,7 +235,7 @@ impl Scroll {
         let nt_mask = Self::NT_Y_MASK | Self::NT_X_MASK;
         // val: ......BA
         // t: ....BA.. ........
-        self.t = (self.t & !nt_mask) | (u16::from(val) & 0x03) << 10; // take lo 2 bits and set NN
+        self.t = (self.t & !nt_mask) | ((u16::from(val) & 0x03) << 10); // take lo 2 bits and set NN
     }
 }
 

--- a/tetanes-core/src/video.rs
+++ b/tetanes-core/src/video.rs
@@ -171,8 +171,8 @@ impl Video {
             };
             prev_color = u32::from(*color);
             assert!(pixels.len() > 2);
-            pixels[0] = (rgba >> 16 & 0xFF) as u8;
-            pixels[1] = (rgba >> 8 & 0xFF) as u8;
+            pixels[0] = ((rgba >> 16) & 0xFF) as u8;
+            pixels[1] = ((rgba >> 8) & 0xFF) as u8;
             pixels[2] = (rgba & 0xFF) as u8;
             // Alpha should always be 255
         }

--- a/tetanes/CHANGELOG.md
+++ b/tetanes/CHANGELOG.md
@@ -1,3 +1,30 @@
+<!-- markdownlint-disable-file no-duplicate-heading -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.12.1](https://github.com/lukexor/tetanes/compare/0.12.0..0.12.1) - 2025-03-13
+
+### ⛰️  Features
+
+
+- Added shortcuts for shaders and ppu warmup flag - ([408b122](https://github.com/lukexor/tetanes/commit/408b122ed98f7edb7a26085fb921aa006bde7091))
+
+### 📚 Documentation
+
+
+- Updated changelog and readmes - ([a4a3e8c](https://github.com/lukexor/tetanes/commit/a4a3e8c0775a7261b91f4238756ac5a20d2c4b48))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Fix/update ci, docs, and fixed nightly issue with tetanes-core - ([ceaed8e](https://github.com/lukexor/tetanes/commit/ceaed8e9e0ced7f693e186ea29e77f01fecfe91c))
+
+
 <!-- markdownlint-disable-file no-duplicate-heading no-multiple-blanks line-length -->
 
 # Changelog

--- a/tetanes/Cargo.toml
+++ b/tetanes/Cargo.toml
@@ -133,8 +133,17 @@ wasm-bindgen-futures = "0.4"
 zip = { version = "2.1", default-features = false, features = ["deflate"] }
 
 [package.metadata.docs.rs]
-rustc-args = ["--cfg=web_sys_unstable_apis"]
-targets = ["wasm32-unknown-unknown"]
+rustc-args = [
+  "--cfg=web_sys_unstable_apis",
+  "--cfg=getrandom_backend=\"wasm_js\"",
+]
+targets = [
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+  "wasm32-unknown-unknown",
+]
 
 [package.metadata.deb]
 extended-description = """


### PR DESCRIPTION



## 🤖 New release

* `tetanes-core`: 0.12.0 -> 0.12.1
* `tetanes`: 0.12.0 -> 0.12.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `tetanes-core`

<blockquote>

## [0.12.1](https://github.com/lukexor/tetanes/compare/0.12.0..0.12.1) - 2025-03-13

### ⛰️  Features


- Added shortcuts for shaders and ppu warmup flag - ([408b122](https://github.com/lukexor/tetanes/commit/408b122ed98f7edb7a26085fb921aa006bde7091))

### 🐛 Bug Fixes


- Fixed issues with some mmc1 games - ([496cf41](https://github.com/lukexor/tetanes/commit/496cf41ced63949fd6d8be5402989e927baf92b8))

### 📚 Documentation


- Updated changelog and readmes - ([a4a3e8c](https://github.com/lukexor/tetanes/commit/a4a3e8c0775a7261b91f4238756ac5a20d2c4b48))

### ⚙️ Miscellaneous Tasks


- Fix/update ci, docs, and fixed nightly issue with tetanes-core - ([ceaed8e](https://github.com/lukexor/tetanes/commit/ceaed8e9e0ced7f693e186ea29e77f01fecfe91c))


<!-- markdownlint-disable-file no-duplicate-heading no-multiple-blanks line-length -->
</blockquote>

## `tetanes`

<blockquote>

## [0.12.1](https://github.com/lukexor/tetanes/compare/0.12.0..0.12.1) - 2025-03-13

### ⛰️  Features


- Added shortcuts for shaders and ppu warmup flag - ([408b122](https://github.com/lukexor/tetanes/commit/408b122ed98f7edb7a26085fb921aa006bde7091))

### 📚 Documentation


- Updated changelog and readmes - ([a4a3e8c](https://github.com/lukexor/tetanes/commit/a4a3e8c0775a7261b91f4238756ac5a20d2c4b48))

### ⚙️ Miscellaneous Tasks


- Fix/update ci, docs, and fixed nightly issue with tetanes-core - ([ceaed8e](https://github.com/lukexor/tetanes/commit/ceaed8e9e0ced7f693e186ea29e77f01fecfe91c))


<!-- markdownlint-disable-file no-duplicate-heading no-multiple-blanks line-length -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).