### PR TITLE
fix: basic cpu error recovery options

### DIFF
--- a/tetanes-core/src/control_deck.rs
+++ b/tetanes-core/src/control_deck.rs
@@ -191,7 +191,7 @@ impl Default for Config {
 }
 
 /// Represents a loaded ROM [`Cart`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoadedRom {
     /// Name of ROM.
     pub name: String,

--- a/tetanes-core/src/sys/fs/os.rs
+++ b/tetanes-core/src/sys/fs/os.rs
@@ -27,6 +27,9 @@ pub fn reader_impl(path: impl AsRef<Path>) -> Result<impl Read> {
 
 pub fn clear_dir_impl(path: impl AsRef<Path>) -> Result<()> {
     let path = path.as_ref();
+    if !path.exists() {
+        return Ok(());
+    }
     remove_dir_all(path)
         .map_err(|source| Error::io(source, format!("failed to remove directory {path:?}")))
 }

--- a/tetanes/src/nes/event.rs
+++ b/tetanes/src/nes/event.rs
@@ -22,6 +22,7 @@ use tetanes_core::{
     apu::{Apu, Channel},
     common::{NesRegion, ResetKind},
     control_deck::{LoadedRom, MapperRevisionsConfig},
+    cpu::instr::Instr,
     debug::Debugger,
     genie::GenieCode,
     input::{FourPlayer, JoypadBtn, Player},
@@ -183,6 +184,7 @@ pub enum EmulationEvent {
     AddDebugger(Debugger),
     RemoveDebugger(Debugger),
     AudioRecord(bool),
+    CpuCorrupted { instr: Instr },
     DebugStep(DebugStep),
     InstantRewind,
     Joypad((Player, JoypadBtn, ElementState)),
@@ -794,7 +796,7 @@ impl Running {
                         }
                     }
                     Err(err) => {
-                        error!("failed top open rom dialog: {err:?}");
+                        error!("failed to open rom dialog: {err:?}");
                         self.event(UiEvent::Error("failed to open rom dialog".to_string()));
                     }
                 }
@@ -812,7 +814,7 @@ impl Running {
                         }
                     }
                     Err(err) => {
-                        error!("failed top open replay dialog: {err:?}");
+                        error!("failed to open replay dialog: {err:?}");
                         self.event(UiEvent::Error("failed to open replay dialog".to_string()));
                     }
                 }

--- a/tetanes/src/nes/renderer/gui/preferences.rs
+++ b/tetanes/src/nes/renderer/gui/preferences.rs
@@ -1092,7 +1092,7 @@ impl State {
         }
     }
 
-    fn clear_save_states(tx: &NesEventProxy) {
+    pub(crate) fn clear_save_states(tx: &NesEventProxy) {
         let data_dir = Config::default_data_dir();
         match fs::clear_dir(data_dir) {
             Ok(_) => tx.event(UiEvent::Message((


### PR DESCRIPTION
Adds basic recovery options in the event of an invalid opcode, corrupting the CPU state.

Also addresses an error deleting save states, when the path doesn't exist as well as fixing some of the RunState mutations in the emulation module to be unidirectional